### PR TITLE
Return false for an empty array in PPArrayUtil::isAssocArray()

### DIFF
--- a/lib/common/PPArrayUtil.php
+++ b/lib/common/PPArrayUtil.php
@@ -8,8 +8,15 @@ class PPArrayUtil {
 	 * @return true if $arr is an associative array
 	 */
 	public static function isAssocArray(array $arr) {
-		foreach($arr as $k => $v)
-			return !is_int($k);
-		return false;
+	    if(empty($arr)) {
+	        return false;
+	    }
+	
+	    foreach($arr as $k => $v) {
+	        if(is_int($k)) {
+	            return false;
+	        }
+	    }
+	    return true;
 	}
 }

--- a/lib/common/PPArrayUtil.php
+++ b/lib/common/PPArrayUtil.php
@@ -1,18 +1,15 @@
 <?php
 
 class PPArrayUtil {
-	
+
 	/**
-	 * 
+	 *
 	 * @param array $arr
 	 * @return true if $arr is an associative array
 	 */
 	public static function isAssocArray(array $arr) {
-		foreach($arr as $k => $v) {
-			if(is_int($k)) {
-				return false;
-			}
-		}
-		return true;
+		foreach($arr as $k => $v)
+			return !is_int($k);
+		return false;
 	}
 }

--- a/tests/common/PPArrayUtilTest.php
+++ b/tests/common/PPArrayUtilTest.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Test class for PPArrayUtil.
+ *
+ */
+class PPArrayUtilTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function testIsArrayAssocEmptyArray()
+    {
+    	$this->assertFalse(PPArrayUtil::isAssocArray(array()));
+    }
+}


### PR DESCRIPTION
Today i had a problem using the PayPal PHP Rest Api. When the PayPal server returns an json string with an empty array for related_resources, the SDK returned an uninitialized object instead of an empty array.

For example
```php
$json = '{"id":"PAY-DUMMY","create_time":"2014-10-03T05:05:31Z","update_time":"2014-10-03T05:05:31Z","state":"created","intent":"sale","payer":{"payment_method":"paypal","payer_info":{"shipping_address":{}}},"transactions":[{"amount":{"total":"82.55","currency":"EUR","details":{"subtotal":"66.71","tax":"13.34","shipping":"2.50"}},"item_list":{"items":[{"name":Dummy","sku":"2","price":"64.92","currency":"EUR","quantity":"1"}]},"related_resources":[]}],"links":[{"href":"https://api.paypal.com/v1/payments/payment/PAY-DUMMY","rel":"self","method":"GET"},{"href":"https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-DUMMY","rel":"approval_url","method":"REDIRECT"},{"href":"https://api.paypal.com/v1/payments/payment/PAY-DUMMY/execute","rel":"execute","method":"POST"}]}';

$m = new PayPal\Api\Payment();
$transactions = $m->getTransactions();
$related_resources = $transactions[0]->getRelatedResources();
$isEmpty = is_empty($related_resouces); // expected to be false
```
In this case the $related_resources was not empty. But contained an uninitialized instance of RelatedResources which was created here: https://github.com/paypal/sdk-core-php/blob/master/lib/common/PPModel.php#L51

