### PR TITLE
Fixed PPBaseService storing state between multiple calls of call()

### DIFF
--- a/lib/PayPal/Core/PPBaseService.php
+++ b/lib/PayPal/Core/PPBaseService.php
@@ -9,7 +9,7 @@ class PPBaseService {
 	private $serviceBinding;
 	private $handlers;
 
-	protected $config;		
+	protected $config;
 	protected $lastRequest;
 	protected $lastResponse;
 
@@ -32,18 +32,18 @@ class PPBaseService {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param string $method - API method to call
-	 * @param object $requestObject Request object 
+	 * @param object $requestObject Request object
 	 * @param apiContext $apiContext object containing credential and SOAP headers
      * @param array $handlers Array of Handlers
 	 * @param mixed $apiUserName - Optional API credential - can either be
-	 * 		a username configured in sdk_config.ini or a ICredential object created dynamically 		
+	 * 		a username configured in sdk_config.ini or a ICredential object created dynamically
 	 */
 	public function call($port, $method, $requestObject, $apiContext, $handlers = array()) {
 
         if (is_array($handlers)) {
-            $this->handlers = $this->handlers + $handlers;
+            $this->handlers = array_merge($this->handlers, $handlers);
         }
 
 		if($apiContext == null)
@@ -51,7 +51,7 @@ class PPBaseService {
 			$apiContext = new PPApiContext(PPConfigManager::getConfigWithDefaults($this->config));
 		}
  		if($apiContext->getConfig() == null )
-		{			
+		{
 			$apiContext->setConfig(PPConfigManager::getConfigWithDefaults($this->config));
 		}
 

--- a/lib/PayPal/Core/PPBaseService.php
+++ b/lib/PayPal/Core/PPBaseService.php
@@ -1,5 +1,6 @@
 <?php
 namespace PayPal\Core;
+
 use PayPal\Core\PPAPIService;
 use PayPal\Common\PPApiContext;
 
@@ -13,10 +14,10 @@ class PPBaseService {
 	protected $lastRequest;
 	protected $lastResponse;
 
-    public function getLastRequest() {
+	public function getLastRequest() {
 		return $this->lastRequest;
 	}
-    public function getLastResponse() {
+	public function getLastResponse() {
 		return $this->lastResponse;
 	}
 
@@ -36,32 +37,34 @@ class PPBaseService {
 	 * @param string $method - API method to call
 	 * @param object $requestObject Request object
 	 * @param apiContext $apiContext object containing credential and SOAP headers
-     * @param array $handlers Array of Handlers
+	 * @param array $handlers Array of Handlers
 	 * @param mixed $apiUserName - Optional API credential - can either be
 	 * 		a username configured in sdk_config.ini or a ICredential object created dynamically
 	 */
 	public function call($port, $method, $requestObject, $apiContext, $handlers = array()) {
 
-        if (is_array($handlers)) {
-            $this->handlers = array_merge($this->handlers, $handlers);
-        }
+		if (!is_array($handlers)) {
+			$handlers = array();
+		}
+
+		if (is_array($this->handlers)) {
+			$handlers = array_merge($this->handlers, $handlers);
+		}
 
 		if($apiContext == null)
 		{
 			$apiContext = new PPApiContext(PPConfigManager::getConfigWithDefaults($this->config));
 		}
- 		if($apiContext->getConfig() == null )
+		if($apiContext->getConfig() == null )
 		{
 			$apiContext->setConfig(PPConfigManager::getConfigWithDefaults($this->config));
 		}
 
 		$service = new PPAPIService($port, $this->serviceName,
-				$this->serviceBinding, $apiContext, $this->handlers);
+				$this->serviceBinding, $apiContext, $handlers);
 		$ret = $service->makeRequest($method, new PPRequest($requestObject, $this->serviceBinding));
 		$this->lastRequest = $ret['request'];
 		$this->lastResponse = $ret['response'];
 		return $this->lastResponse;
 	}
-
-
 }

--- a/tests/Mocks.php
+++ b/tests/Mocks.php
@@ -1,0 +1,23 @@
+<?php
+
+use PayPal\Handler\IPPHandler;
+
+class MockNVPClass {
+    public function toNVPString() {
+        return 'invoiceID=INV2-6657-UHKM-3LWC-JHF7';
+    }
+}
+
+class MockHandler  implements IPPHandler {
+
+    public function handle($httpConfig, $request, $options) {
+        $config = $options['config'];
+        $httpConfig->setUrl('https://svcs.sandbox.paypal.com/Invoice/GetInvoiceDetails');
+        $httpConfig->addHeader('X-PAYPAL-REQUEST-DATA-FORMAT', 'NV');
+        $httpConfig->addHeader('X-PAYPAL-RESPONSE-DATA-FORMAT', 'NV');
+        $httpConfig->addHeader('X-PAYPAL-SECURITY-USERID', 'jb-us-seller_api1.paypal.com');
+        $httpConfig->addHeader('X-PAYPAL-SECURITY-PASSWORD', 'WX4WTU3S8MY44S7F');
+        $httpConfig->addHeader('X-PAYPAL-SECURITY-SIGNATURE', 'AFcWxV21C7fd0v3bYYYRCpSSRl31A7yDhhsPUU2XhtMoZXsWHFxu-RWy');
+    }
+}
+

--- a/tests/PPAPIServiceTest.php
+++ b/tests/PPAPIServiceTest.php
@@ -1,8 +1,11 @@
 <?php
+
+require_once 'Mocks.php';
+
 use PayPal\Core\PPAPIService;
 use PayPal\Core\PPRequest;
 use PayPal\Common\PPApiContext;
-use PayPal\Handler\IPPHandler;
+
 
 /**
  * Test class for PPAPIService.
@@ -14,7 +17,7 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
      * @var PPAPIService
      */
     protected $object;
-    
+
     private $config = array(
     		'acct1.UserName' => 'jb-us-seller_api1.paypal.com'	,
     		'acct1.Password' => 'WX4WTU3S8MY44S7F'	,
@@ -34,8 +37,8 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
     		'log.FileName' => 'PayPal.log'	,
     		'log.LogLevel' => 	'INFO'	,
     		'log.LogEnabled' => 	'1'	,
-    
-    
+
+
     );
 
     /**
@@ -59,7 +62,7 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
      * @test
      */
     public function testSetServiceName()
-    {  
+    {
     	$this->assertEquals('Invoice', $this->object->serviceName);
     	$this->object->setServiceName('AdaptiveAccounts');
         $this->assertEquals('AdaptiveAccounts', $this->object->serviceName);
@@ -73,8 +76,8 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
     	$this->setExpectedException('PayPal\Exception\PPConnectionException');
 	$req = new PPRequest(new MockNVPClass(), "NV");
 	$this->object->makeRequest('GetInvoiceDetails', $req);
-    }    
-    
+    }
+
     /**
      * @test
      */
@@ -82,29 +85,8 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
     	$this->object->addHandler(new MockHandler());
 	$req = new PPRequest(new MockNVPClass(), "NV");
     	$ret = $this->object->makeRequest('GetInvoiceDetails', $req);
-    	
+
     	$this->assertArrayHasKey('response', $ret);
     	$this->assertContains("responseEnvelope.timestamp=", $ret['response']);
     }
 }
-
-class MockNVPClass {
-	public function toNVPString() {
-		return 'invoiceID=INV2-6657-UHKM-3LWC-JHF7';
-	}
-}
-
-class MockHandler  implements IPPHandler {
-
-	public function handle($httpConfig, $request, $options) {
-		$config = $options['config'];
-		$httpConfig->setUrl('https://svcs.sandbox.paypal.com/Invoice/GetInvoiceDetails');
-		$httpConfig->addHeader('X-PAYPAL-REQUEST-DATA-FORMAT', 'NV');
-		$httpConfig->addHeader('X-PAYPAL-RESPONSE-DATA-FORMAT', 'NV');
-		$httpConfig->addHeader('X-PAYPAL-SECURITY-USERID', 'jb-us-seller_api1.paypal.com');
-		$httpConfig->addHeader('X-PAYPAL-SECURITY-PASSWORD', 'WX4WTU3S8MY44S7F');
-		$httpConfig->addHeader('X-PAYPAL-SECURITY-SIGNATURE', 'AFcWxV21C7fd0v3bYYYRCpSSRl31A7yDhhsPUU2XhtMoZXsWHFxu-RWy');
-	}
-
-}
-?>

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -82,4 +82,23 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
         $req = new MockNVPClass();
         $ret = $this->object->call(null, 'GetInvoiceDetails', $req, null, array($handler));
     }
+
+    public function testMultipleCallsDoesntIncludePreviousCallHandlers()
+    {
+        $firstHandler = $this->getMock('\PayPal\Handler\IPPHandler');
+        $firstHandler
+            ->expects($this->once())
+            ->method('handle');
+
+        $req = new MockNVPClass();
+        $ret = $this->object->call(null, 'GetInvoiceDetails', $req, null, array($firstHandler));
+
+        $secondHandler = $this->getMock('\PayPal\Handler\IPPHandler');
+        $secondHandler
+            ->expects($this->once())
+            ->method('handle');
+
+        $req = new MockNVPClass();
+        $ret = $this->object->call(null, 'GetInvoiceDetails', $req, null, array($secondHandler));
+    }
 }

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -71,4 +71,15 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
     	$this->assertEquals($ret, $this->object->getLastResponse());
 
     }
+
+    public function testMakeRequestWithServiceHandlerAndCallHandler()
+    {
+        $handler = $this->getMock('\PayPal\Handler\IPPHandler');
+        $handler
+            ->expects($this->once())
+            ->method('handle');
+
+        $req = new MockNVPClass();
+        $ret = $this->object->call(null, 'GetInvoiceDetails', $req, null, array($handler));
+    }
 }

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -10,7 +10,7 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
      * @var PPBaseService
      */
     protected $object;
-    
+
     private $config = array(
     		'acct1.UserName' => 'jb-us-seller_api1.paypal.com'	,
     		'acct1.Password' => 'WX4WTU3S8MY44S7F'	,
@@ -38,7 +38,7 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->object = new PPBaseService('Invoice', 'NV', array(new MockHandler()), $this->config);
+        $this->object = new PPBaseService('Invoice', 'NV', $this->config, array(new MockHandler()));
     }
 
     /**
@@ -66,7 +66,6 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
     	$this->assertContains("responseEnvelope.timestamp=", $ret);
     	$this->assertEquals($req->toNVPString(), $this->object->getLastRequest());
     	$this->assertEquals($ret, $this->object->getLastResponse());
-    	
+
     }
 }
-?>

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once 'Mocks.php';
+
 use PayPal\Core\PPBaseService;
 /**
  * Test class for PPBaseService.


### PR DESCRIPTION
`PPBaseService` was storing handlers passed into `call()` on the service itself meaning any subsequent calls to `call()` would also include those handlers.

This causes lots of problems, such as when switching auth mechanisms between calls. 