### PR TITLE
IPN's txn_type isn't always set.

### DIFF
--- a/lib/PayPal/IPN/PPIPNMessage.php
+++ b/lib/PayPal/IPN/PPIPNMessage.php
@@ -134,7 +134,7 @@ class PPIPNMessage {
 	public function getTransactionType() {
 		// Check if transaction_type present. Otherwise, use txn_type
 		if (!isset($this->ipnData['transaction_type'])) {
-			return $this->ipnData['txn_type'];
+			return (isset($this->ipnData['txn_type']) ?: '');
 		}
 		return $this->ipnData['transaction_type'];
 	}


### PR DESCRIPTION
If you set an IPN notification url inside your Paypal ( Paypal Profile -> Selling Tools -> Instant payment notifications ) and then perform a refund. The following type of IPN message is sent to that URL. This type of IPN message does not contain a `txn_type` field and is thus causing an exception to be thrown.

ErrorException Undefined index: txn_type

Please see example IPN message below:

`{
    "custom": "",
    "mc_fee": "-0.44",
    "txn_id": "9HW359788T334003Y",
    "charset": "windows-1252",
    "invoice": "INV-115",
    "business": "payments-facilitator@email.net",
    "mc_gross": "-15.00",
    "payer_id": "T22GB3BYCWGSW",
    "shipping": "0.00",
    "test_ipn": "1",
    "item_name": "",
    "last_name": "buyer",
    "first_name": "test",
    "item_number": "",
    "mc_currency": "USD",
    "payer_email": "payments-buyer@email.net",
    "payment_fee": "-0.44",
    "reason_code": "refund",
    "receiver_id": "3CL9GPHUL9B2S",
    "verify_sign": "AiKZhEEPLJjSIccz.2M.tbyW5YFwAJtXpqqC12zyIhK6VBx57OvH6bDR",
    "ipn_track_id": "c6fda0c6b8108",
    "payment_date": "17:33:09 Mar 03, 2016 PST",
    "payment_type": "instant",
    "parent_txn_id": "1YL83257AJ191483F",
    "payment_gross": "-15.00",
    "notify_version": "3.8",
    "payment_status": "Refunded",
    "receiver_email": "payments-facilitator@email.net",
    "handling_amount": "0.00",
    "residence_country": "US",
    "transaction_subject": "",
    "protection_eligibility": "Ineligible"
}`