### PR TITLE
Fix for warning in PPConfigManager

### DIFF
--- a/lib/PayPal/Core/PPConfigManager.php
+++ b/lib/PayPal/Core/PPConfigManager.php
@@ -124,6 +124,7 @@ class PPConfigManager
      */
     public static function getConfigWithDefaults($config = null)
     {
+        if (!is_array(PPConfigManager::getInstance()->getConfigHashmap()) && $config == null) return PPConfigManager::$defaults;
         return array_merge(PPConfigManager::$defaults,
           ($config != null) ? $config : PPConfigManager::getInstance()->getConfigHashmap());
     }


### PR DESCRIPTION
PHP can issue a warning because array_merge expects two arrays as parameter, but getConfigHashmap() can be null.