### PR TITLE
Travis: initial configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+
+install:
+  - composer install
+
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
It would be nice to automatically run test suite on each PR & merge (to ensure compatibility with all supported PHP versions and no tests break).

@jaypatel512: would you be able to enable travis for `paypal` organization? it should be here possible to do here: https://travis-ci.org/profile/paypal

Afterwards, i'll re-push my changes to trigger travis build.