### PR TITLE
Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["paypal", "php", "sdk"],
     "type": "library",
     "homepage": "https://github.com/paypal/sdk-core-php",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "PayPal",


### PR DESCRIPTION
Running `composer validate` makes Composer throw the following warning:

> License "Apache2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.

The proper SPDX license identifier is `Apache-2.0`.
