### PR TITLE
Set CURLOPT_TIMEOUT in setHttpTimeout method

### DIFF
--- a/lib/PayPal/Core/PPHttpConfig.php
+++ b/lib/PayPal/Core/PPHttpConfig.php
@@ -150,7 +150,7 @@ class PPHttpConfig
      */
     public function setHttpTimeout($timeout)
     {
-        $this->curlOptions[CURLOPT_CONNECTTIMEOUT] = $timeout;
+        $this->curlOptions[CURLOPT_TIMEOUT] = $timeout;
     }
 
     /**


### PR DESCRIPTION
Currently CURLOPT_CONNECTTIMEOUT is set in that method.