### PR TITLE
add http.TimeOut config value to make curl timeout configurable

### DIFF
--- a/lib/PayPal/Core/PPConfigManager.php
+++ b/lib/PayPal/Core/PPConfigManager.php
@@ -13,6 +13,7 @@ class PPConfigManager
     //default config values
     public static $defaults = array(
       "http.ConnectionTimeOut" => "30",
+      "http.TimeOut"           => "60",
       "http.Retry"             => "5",
     );
 

--- a/lib/PayPal/Core/PPConnectionManager.php
+++ b/lib/PayPal/Core/PPConnectionManager.php
@@ -27,7 +27,10 @@ class PPConnectionManager
     public function getConnection($httpConfig, $config)
     {
         if (isset($config["http.ConnectionTimeOut"])) {
-            $httpConfig->setHttpTimeout($config["http.ConnectionTimeOut"]);
+            $httpConfig->setHttpConnectionTimeout($config["http.ConnectionTimeOut"]);
+        }
+        if (isset($config["http.TimeOut"])) {
+            $httpConfig->setHttpTimeout($config["http.TimeOut"]);
         }
         if (isset($config["http.Proxy"])) {
             $httpConfig->setHttpProxy($config["http.Proxy"]);

--- a/lib/PayPal/Core/PPHttpConfig.php
+++ b/lib/PayPal/Core/PPHttpConfig.php
@@ -148,9 +148,19 @@ class PPHttpConfig
      *
      * @param integer $timeout
      */
-    public function setHttpTimeout($timeout)
+    public function setHttpConnectionTimeout($timeout)
     {
         $this->curlOptions[CURLOPT_CONNECTTIMEOUT] = $timeout;
+    }
+
+    /**
+     * Set timeout in seconds
+     *
+     * @param integer $timeout
+     */
+    public function setHttpTimeout($timeout)
+    {
+        $this->curlOptions[CURLOPT_TIMEOUT] = $timeout;
     }
 
     /**

--- a/tests/PPAPIServiceTest.php
+++ b/tests/PPAPIServiceTest.php
@@ -28,6 +28,7 @@ class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
     		'acct2.CertPath' => 	'cert_key.pem'	,
     		'acct2.AppId' => 	'APP-80W284485P519543T'	,
     		'http.ConnectionTimeOut' => 	'30'	,
+    		'http.TimeOut' => 	'60'	,
     		'http.Retry' => 	'5'	,
     		'service.RedirectURL' => 	'https://www.sandbox.paypal.com/webscr&cmd='	,
     		'service.DevCentralURL' => 'https://developer.paypal.com'	,

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -24,6 +24,7 @@ class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
     		'acct2.CertPath' => 	'cert_key.pem'	,
     		'acct2.AppId' => 	'APP-80W284485P519543T'	,
     		'http.ConnectionTimeOut' => 	'30'	,
+    		'http.TimeOut' => 	'60'	,
     		'http.Retry' => 	'5'	,
     		'service.RedirectURL' => 	'https://www.sandbox.paypal.com/webscr&cmd='	,
     		'service.DevCentralURL' => 'https://developer.paypal.com'	,

--- a/tests/PPConfigManagerTest.php
+++ b/tests/PPConfigManagerTest.php
@@ -48,7 +48,7 @@ class PPConfigManagerTest extends \PHPUnit_Framework_TestCase
 		$this->assertContains('jb-us-seller_api1.paypal.com', $ret);
 		$this->assertArrayHasKey('acct1.UserName', $ret);
 		$this->assertTrue(sizeof($ret) == 7);
-	
+
 		$ret = $this->object->get('acct1.UserName');
 		$this->assertEquals('jb-us-seller_api1.paypal.com', $ret);
 
@@ -65,7 +65,7 @@ class PPConfigManagerTest extends \PHPUnit_Framework_TestCase
 		$ret = $this->object->getIniPrefix();
 		$this->assertContains('acct1', $ret);
 		$this->assertEquals(sizeof($ret), 2);
-		
+
 		$ret = $this->object->getIniPrefix('jb-us-seller_api1.paypal.com');
 		$this->assertEquals('acct1', $ret);
 	}
@@ -80,19 +80,22 @@ class PPConfigManagerTest extends \PHPUnit_Framework_TestCase
 		$this->assertArrayHasKey('mode', $config, 'file config not read when no custom config is passed');
 		$this->assertEquals('sandbox', $config['mode']);
 		$this->assertEquals(60, $config['http.ConnectionTimeOut']);
+		$this->assertEquals(120, $config['http.TimeOut']);
 
 		// Test custom config params and defaults
 		$config = PPConfigManager::getInstance()->getConfigWithDefaults(array('mode' => 'custom'));
 		$this->assertArrayHasKey('mode', $config);
 		$this->assertEquals('custom', $config['mode']);
 		$this->assertEquals(30, $config['http.ConnectionTimeOut']);
+		$this->assertEquals(60, $config['http.TimeOut']);
 
 		// Test override for default connection params
 		$config = PPConfigManager::getInstance()->getConfigWithDefaults(
-				array('mode' => 'custom', 'http.ConnectionTimeOut' => 100));
+				array('mode' => 'custom', 'http.ConnectionTimeOut' => 100, 'http.TimeOut' => 200));
 		$this->assertArrayHasKey('mode', $config);
 		$this->assertEquals('custom', $config['mode']);
 		$this->assertEquals(100, $config['http.ConnectionTimeOut']);
+		$this->assertEquals(200, $config['http.TimeOut']);
 	}
 }
 ?>

--- a/tests/PPConnectionManagerTest.php
+++ b/tests/PPConnectionManagerTest.php
@@ -12,7 +12,7 @@ class PPConnectionManagerTest extends \PHPUnit_Framework_TestCase
      * @var PPConnectionManager
      */
     protected $object;
-    
+
     private $config = array(
     		'acct1.UserName' => 'jb-us-seller_api1.paypal.com'	,
     		'acct1.Password' => 'WX4WTU3S8MY44S7F'	,
@@ -23,6 +23,7 @@ class PPConnectionManagerTest extends \PHPUnit_Framework_TestCase
     		'acct2.CertPath' => 	'cert_key.pem'	,
     		'acct2.AppId' => 	'APP-80W284485P519543T'	,
     		'http.ConnectionTimeOut' => 	'30'	,
+    		'http.TimeOut' => 	'60'	,
     		'http.Retry' => 	'5'	,
     		'service.RedirectURL' => 	'https://www.sandbox.paypal.com/webscr&cmd='	,
     		'service.DevCentralURL' => 'https://developer.paypal.com'	,
@@ -32,8 +33,8 @@ class PPConnectionManagerTest extends \PHPUnit_Framework_TestCase
     		'log.FileName' => 'PayPal.log'	,
     		'log.LogLevel' => 	'INFO'	,
     		'log.LogEnabled' => 	'1'	,
-    
-    
+
+
     );
 
     /**

--- a/tests/PPCredentialManagerTest.php
+++ b/tests/PPCredentialManagerTest.php
@@ -24,6 +24,7 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 			'acct3.ClientId' => 		'client-id',
 			'acct3.ClientSecret' => 	'client-secret',
 			'http.ConnectionTimeOut' => '30',
+			'http.TimeOut' => '60',
 			'http.Retry' => 			'5',
 			'service.RedirectURL' => 	'https://www.sandbox.paypal.com/webscr&cmd=',
 			'service.DevCentralURL' => 	'https://developer.paypal.com',
@@ -68,13 +69,13 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 		$cred = $this->object->getCredentialObject('jb-us-seller_api1.paypal.com');
 		$this->assertNotNull($cred);
 		$this->assertEquals('jb-us-seller_api1.paypal.com', $cred->getUsername());
-		
+
 		$cred = $this->object->getCredentialObject('certuser_biz_api1.paypal.com');
 		$this->assertNotNull($cred);
 		$this->assertEquals('certuser_biz_api1.paypal.com', $cred->getUsername());
-		$this->assertStringEndsWith('cert_key.pem', $cred->getCertificatePath());		
+		$this->assertStringEndsWith('cert_key.pem', $cred->getCertificatePath());
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -83,7 +84,7 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 		$this->setExpectedException('PayPal\Exception\PPInvalidCredentialException');
 		$cred = $this->object->getCredentialObject('invalid_biz_api1.gmail.com');
 	}
-		
+
 	/**
 	 * @test
 	 */
@@ -91,7 +92,7 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 	{
 		$cred = $this->object->getCredentialObject();
 		$this->assertEquals('jb-us-seller_api1.paypal.com', $cred->getUsername());
-		
+
 		// Test to see if default account for REST credentials works
 		// as expected
 		$o = PPCredentialManager::getInstance(array(
@@ -105,8 +106,8 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 		));
 		$cred = $o->getCredentialObject();
 		$this->assertEquals('client-id', $cred['clientId']);
-	}	
-	
+	}
+
 	/**
 	 * @test
 	 */
@@ -126,13 +127,13 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 		$this->assertNotNull($cred->getThirdPartyAuthorization());
 		$this->assertEquals('PayPal\Auth\PPSubjectAuthorization', get_class($cred->getThirdPartyAuthorization()));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testGetRestCredentialObject() {
 		$cred = $this->object->getCredentialObject('acct3');
-	
+
 		$this->assertNotNull($cred);
 
 		$this->assertArrayHasKey('clientId', $cred);
@@ -141,7 +142,7 @@ class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
 		$this->assertArrayHasKey('clientSecret', $cred);
 		$this->assertEquals($this->config['acct3.ClientSecret'], $cred['clientSecret']);
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/PPHttpConfigTest.php
+++ b/tests/PPHttpConfigTest.php
@@ -6,12 +6,13 @@ use PayPal\Core\PPHttpConfig;
  */
 class PPHttpConfigTest extends PHPUnit_Framework_TestCase
 {
-   
+
     protected $object;
-    
+
     private $config = array(
 		'http.ConnectionTimeOut' => '30',
-		'http.Retry' => '5'	,    		
+		'http.TimeOut' => '60',
+		'http.Retry' => '5'	,
     );
 
     /**
@@ -20,7 +21,7 @@ class PPHttpConfigTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        
+
     }
 
     /**
@@ -35,29 +36,29 @@ class PPHttpConfigTest extends PHPUnit_Framework_TestCase
      * @test
      */
     public function testHeaderFunctions()
-    {  
+    {
     	$o = new PPHttpConfig();
     	$o->addHeader('key1', 'value1');
     	$o->addHeader('key2', 'value');
     	$o->addHeader('key2', 'overwritten');
-    	
+
     	$this->assertEquals(2, count($o->getHeaders()));
     	$this->assertEquals('overwritten', $o->getHeader('key2'));
     	$this->assertNull($o->getHeader('key3'));
-    	
+
     	$o = new PPHttpConfig();
     	$o->addHeader('key1', 'value1');
     	$o->addHeader('key2', 'value');
     	$o->addHeader('key2', 'and more', false);
-    	 
+
     	$this->assertEquals(2, count($o->getHeaders()));
     	$this->assertEquals('value;and more', $o->getHeader('key2'));
-    	
+
     	$o->removeHeader('key2');
     	$this->assertEquals(1, count($o->getHeaders()));
     	$this->assertNull($o->getHeader('key2'));
     }
-    
+
     /**
      * @test
      */
@@ -65,12 +66,12 @@ class PPHttpConfigTest extends PHPUnit_Framework_TestCase
     {
     	$o = new PPHttpConfig();
     	$o->setCurlOptions(array('k' => 'v'));
-    	
+
     	$curlOpts = $o->getCurlOptions();
     	$this->assertEquals(1, count($curlOpts));
     	$this->assertEquals('v', $curlOpts['k']);
     }
-    
+
     /**
      * @test
      */
@@ -79,11 +80,11 @@ class PPHttpConfigTest extends PHPUnit_Framework_TestCase
     	$ua = 'UAString';
     	$o = new PPHttpConfig();
     	$o->setUserAgent($ua);
-    	
+
     	$curlOpts= $o->getCurlOptions();
     	$this->assertEquals($ua, $curlOpts[CURLOPT_USERAGENT]);
     }
-    
+
     /**
      * @test
      */
@@ -91,29 +92,29 @@ class PPHttpConfigTest extends PHPUnit_Framework_TestCase
     {
     	$sslCert = '../cacert.pem';
     	$sslPass = 'passPhrase';
-    	
+
     	$o = new PPHttpConfig();
     	$o->setSSLCert($sslCert, $sslPass);
-    	 
+
     	$curlOpts= $o->getCurlOptions();
     	$this->assertArrayHasKey(CURLOPT_SSLCERT, $curlOpts);
     	$this->assertEquals($sslPass, $curlOpts[CURLOPT_SSLCERTPASSWD]);
     }
-    
+
     /**
      * @test
      */
     public function testProxyOpts()
     {
     	$proxy = 'http://me:secret@hostname:8081';
-    	 
+
     	$o = new PPHttpConfig();
     	$o->setHttpProxy($proxy);
-    
+
     	$curlOpts= $o->getCurlOptions();
     	$this->assertEquals('hostname:8081', $curlOpts[CURLOPT_PROXY]);
     	$this->assertEquals('me:secret', $curlOpts[CURLOPT_PROXYUSERPWD]);
-    	
+
     	$this->setExpectedException('PayPal\Exception\PPConfigurationException');
     	$o->setHttpProxy('invalid string');
     }

--- a/tests/sdk_config.ini
+++ b/tests/sdk_config.ini
@@ -2,13 +2,13 @@
 [Account]
 
 acct1.ClientId = AQkquBDf1zctJOWGKWUEtKXm6qVhueUEMvXO_-MCI4DQQ4-LWvkDLIN2fGsd
-acct1.ClientSecret = EL1tVxAjhT7cJimnz5-Nsx9k2reTKSVfErNQF-CmrwJgxRtylkGTKlU4RvrX 
+acct1.ClientSecret = EL1tVxAjhT7cJimnz5-Nsx9k2reTKSVfErNQF-CmrwJgxRtylkGTKlU4RvrX
 acct1.UserName = jb-us-seller_api1.paypal.com
 acct1.Password = WX4WTU3S8MY44S7F
 acct1.Signature = AFcWxV21C7fd0v3bYYYRCpSSRl31A7yDhhsPUU2XhtMoZXsWHFxu-RWy
 acct1.AppId = APP-80W284485P519543T
-# Subject is optional and is required only in case of third party authorization 
-acct1.Subject = 
+# Subject is optional and is required only in case of third party authorization
+acct1.Subject =
 
 ; Certificate Credentials Test Account
 acct2.UserName = platfo_1255170694_biz_api1.gmail.com
@@ -20,6 +20,7 @@ acct2.CertPath = cacert.pem
 ;Connection Information
 [Http]
 http.ConnectionTimeOut = 60
+http.TimeOut = 120
 ;http.Retry = 1
 ;http.Proxy
 
@@ -30,4 +31,4 @@ log.LogLevel=INFO
 log.LogEnabled=true
 
 mode = sandbox
- 
+


### PR DESCRIPTION
- add `http.TimeOut` to configuration values that is used to set `CURLOPT_TIMEOUT`
- fixes #98