### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-0": {
             "PayPal": "lib/"
         }
-    } 
+    }
 }

--- a/tests/Openid/PPOpenIdAddressTest.php
+++ b/tests/Openid/PPOpenIdAddressTest.php
@@ -1,11 +1,12 @@
-<?php 
+<?php
 use PayPal\Auth\Openid\PPOpenIdAddress;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPOpenIdAddress.
  *
  */
-class PPOpenIdAddressTest extends \PHPUnit_Framework_TestCase {
-	
+class PPOpenIdAddressTest extends TestCase {
+
 	private $addr;
 
 	/**
@@ -15,7 +16,7 @@ class PPOpenIdAddressTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		$this->addr = self::getTestData();
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
@@ -23,7 +24,7 @@ class PPOpenIdAddressTest extends \PHPUnit_Framework_TestCase {
 	protected function tearDown()
 	{
 	}
-	
+
 	public static function getTestData() {
 		$addr = new PPOpenIdAddress();
 		$addr->setCountry("US")->setLocality("San Jose")
@@ -31,14 +32,14 @@ class PPOpenIdAddressTest extends \PHPUnit_Framework_TestCase {
 		->setStreetAddress("1, North 1'st street");
 		return $addr;
 	}
-	
+
 	/**
 	 * @test
 	 */
-	public function testSerializationDeserialization() {				
+	public function testSerializationDeserialization() {
 		$addrCopy = new PPOpenIdAddress();
 		$addrCopy->fromJson($this->addr->toJson());
-		
+
 		$this->assertEquals($this->addr, $addrCopy);
 	}
 }

--- a/tests/Openid/PPOpenIdErrorTest.php
+++ b/tests/Openid/PPOpenIdErrorTest.php
@@ -1,12 +1,13 @@
-<?php 
+<?php
 
 use PayPal\Auth\Openid\PPOpenIdError;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPOpenIdError.
  *
  */
-class PPOpenIdErrorTest extends PHPUnit_Framework_TestCase {
-	
+class PPOpenIdErrorTest extends TestCase {
+
 	private $error;
 
 	/**
@@ -19,7 +20,7 @@ class PPOpenIdErrorTest extends PHPUnit_Framework_TestCase {
 			->setErrorUri('http://developer.paypal.com/api/error')
 			->setError('VALIDATION_ERROR');
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
@@ -27,14 +28,14 @@ class PPOpenIdErrorTest extends PHPUnit_Framework_TestCase {
 	protected function tearDown()
 	{
 	}
-	
+
 	/**
 	 * @test
 	 */
-	public function testSerializationDeserialization() {				
+	public function testSerializationDeserialization() {
 		$errorCopy = new PPOpenIdError();
 		$errorCopy->fromJson($this->error->toJson());
-		
+
 		$this->assertEquals($this->error, $errorCopy);
 	}
 }

--- a/tests/Openid/PPOpenIdSessionTest.php
+++ b/tests/Openid/PPOpenIdSessionTest.php
@@ -1,12 +1,13 @@
 <?php
 use PayPal\Common\PPApiContext;
 use PayPal\Auth\Openid\PPOpenIdSession;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPOpenIdSession.
  *
  */
-class PPOpenIdSessionTest extends \PHPUnit_Framework_TestCase {
-	
+class PPOpenIdSessionTest extends TestCase {
+
 	private $context;
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -22,7 +23,7 @@ class PPOpenIdSessionTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
@@ -30,56 +31,56 @@ class PPOpenIdSessionTest extends \PHPUnit_Framework_TestCase {
 	protected function tearDown()
 	{
 	}
-	
+
 
 	/**
 	 * @test
 	 */
 	public function testLoginUrlForMultipleScopes() {
-	
+
 		$clientId = "AQkquBDf1zctJOWGKWUEtKXm6qVhueUEMvXO_-MCI4DQQ4-LWvkDLIN2fGsd";
 		$redirectUri = 'https://devtools-paypal.com/';
 		$scope = array('this', 'that', 'and more');
 
 		$expectedBaseUrl = "https://www.sandbox.paypal.com/signin/authorize";
-	
+
 		$this->assertEquals($expectedBaseUrl . "?client_id=$clientId&response_type=code&scope=this+that+and+more+openid&redirect_uri=" . urlencode($redirectUri),
 				PPOpenIdSession::getAuthorizationUrl($redirectUri, $scope, $clientId), "Failed case - custom scope");
-	
+
 		$scope = array();
 		$this->assertEquals($expectedBaseUrl . "?client_id=$clientId&response_type=code&scope=openid+profile+address+email+phone+" . urlencode("https://uri.paypal.com/services/paypalattributes") ."+". urlencode('https://uri.paypal.com/services/expresscheckout') . "&redirect_uri=" . urlencode($redirectUri),
 				PPOpenIdSession::getAuthorizationUrl($redirectUri, $scope, $clientId), "Failed case - default scope");
 
-	
+
 		$scope = array('openid');
 		$this->assertEquals($expectedBaseUrl . "?client_id=$clientId&response_type=code&scope=openid&redirect_uri=" . urlencode($redirectUri),
 				PPOpenIdSession::getAuthorizationUrl($redirectUri, $scope, $clientId), "Failed case - openid scope");
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testLoginWithCustomConfig() {
-	
+
 		$redirectUri = 'http://mywebsite.com';
 		$scope = array('this', 'that', 'and more');
-	
+
 		$expectedBaseUrl = "https://www.paypal.com/signin/authorize";
-			
+
 		$this->assertEquals($expectedBaseUrl . "?client_id=DummyId&response_type=code&scope=this+that+and+more+openid&redirect_uri=" . urlencode($redirectUri),
 				PPOpenIdSession::getAuthorizationUrl($redirectUri, $scope, "DummyId", null, null, $this->context), "Failed case - custom config");
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testLogoutWithCustomConfig() {
-		
+
 		$redirectUri = 'http://mywebsite.com';
 		$idToken = 'abc';
-		
+
 		$expectedBaseUrl = "https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/endsession";
-			
+
 		$this->assertEquals($expectedBaseUrl . "?id_token=$idToken&redirect_uri=" . urlencode($redirectUri) . "&logout=true",
 				PPOpenIdSession::getLogoutUrl($redirectUri, $idToken, $this->context), "Failed case - custom config");
 	}

--- a/tests/Openid/PPOpenIdTokeninfoTest.php
+++ b/tests/Openid/PPOpenIdTokeninfoTest.php
@@ -1,12 +1,12 @@
-<?php 
+<?php
 use PayPal\Auth\Openid\PPOpenIdTokeninfo;
-
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPOpenIdTokeninfo.
  *
  */
-class PPOpenIdTokeninfoTest extends \PHPUnit_Framework_TestCase {
-	
+class PPOpenIdTokeninfoTest extends TestCase {
+
 	public $token;
 
 	/**
@@ -22,7 +22,7 @@ class PPOpenIdTokeninfoTest extends \PHPUnit_Framework_TestCase {
 					->setScope("openid address")
 					->setTokenType("Bearer");
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
@@ -30,17 +30,17 @@ class PPOpenIdTokeninfoTest extends \PHPUnit_Framework_TestCase {
 	protected function tearDown()
 	{
 	}
-	
+
 	/**
 	 * @test
 	 */
-	public function testSerializationDeserialization() {				
+	public function testSerializationDeserialization() {
 		$tokenCopy = new PPOpenIdTokeninfo();
 		$tokenCopy->fromJson($this->token->toJson());
-		
+
 		$this->assertEquals($this->token, $tokenCopy);
 	}
-	
+
 	/**
 	 * @t1est
 	 */

--- a/tests/Openid/PPOpenIdUserinfoTest.php
+++ b/tests/Openid/PPOpenIdUserinfoTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Auth\Openid\PPOpenIdUserinfo;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPOpenIdUserinfo.
  *
  */
-class PPOpenIdUserinfoTest extends \PHPUnit_Framework_TestCase {
-	
+class PPOpenIdUserinfoTest extends TestCase {
+
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -14,7 +15,7 @@ class PPOpenIdUserinfoTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp()
 	{
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
@@ -22,7 +23,7 @@ class PPOpenIdUserinfoTest extends \PHPUnit_Framework_TestCase {
 	protected function tearDown()
 	{
 	}
-	
+
 
 	/**
 	 * @test
@@ -39,13 +40,13 @@ class PPOpenIdUserinfoTest extends \PHPUnit_Framework_TestCase {
 			->setVerified(true)->setVerifiedAccount(true)
 			->setZoneinfo("America/PST")->setLanguage('en_US')
 			->setAddress(PPOpenIdAddressTest::getTestData());
-		
+
 		$userCopy = new PPOpenIdUserinfo();
 		$userCopy->fromJson($user->toJSON());
-		
+
 		$this->assertEquals($user, $userCopy);
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/PPAPIServiceTest.php
+++ b/tests/PPAPIServiceTest.php
@@ -5,13 +5,13 @@ require_once 'Mocks.php';
 use PayPal\Core\PPAPIService;
 use PayPal\Core\PPRequest;
 use PayPal\Common\PPApiContext;
-
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PPAPIService.
  *
  */
-class PPAPIServiceTest extends \PHPUnit_Framework_TestCase
+class PPAPIServiceTest extends TestCase
 {
     /**
      * @var PPAPIService

--- a/tests/PPBaseServiceTest.php
+++ b/tests/PPBaseServiceTest.php
@@ -3,11 +3,12 @@
 require_once 'Mocks.php';
 
 use PayPal\Core\PPBaseService;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPBaseService.
  *
  */
-class PPBaseServiceTest extends \PHPUnit_Framework_TestCase
+class PPBaseServiceTest extends TestCase
 {
     /**
      * @var PPBaseService

--- a/tests/PPCertificateCredentialTest.php
+++ b/tests/PPCertificateCredentialTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Auth\PPCertificateCredential;
 use PayPal\Exception\PPMissingCredentialException;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPCertificateCredential.
  *
  */
-class PPCertificateCredentialTest extends \PHPUnit_Framework_TestCase
+class PPCertificateCredentialTest extends TestCase
 {
 	/**
 	 * @var PPCertificateCredential

--- a/tests/PPConfigManagerTest.php
+++ b/tests/PPConfigManagerTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPConfigManager;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPConfigManager.
  *
  */
-class PPConfigManagerTest extends \PHPUnit_Framework_TestCase
+class PPConfigManagerTest extends TestCase
 {
 	/**
 	 * @var PPConfigManager

--- a/tests/PPConfigurationExceptionTest.php
+++ b/tests/PPConfigurationExceptionTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Exception\PPConfigurationException;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPConfigurationException.
  *
  */
-class PPConfigurationExceptionTest extends \PHPUnit_Framework_TestCase
+class PPConfigurationExceptionTest extends TestCase
 {
     /**
      * @var PPConfigurationException

--- a/tests/PPConnectionExceptionTest.php
+++ b/tests/PPConnectionExceptionTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Exception\PPConnectionException;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPConnectionException.
  *
  */
-class PPConnectionExceptionTest extends \PHPUnit_Framework_TestCase
+class PPConnectionExceptionTest extends TestCase
 {
     /**
      * @var PPConnectionException
@@ -36,13 +37,13 @@ class PPConnectionExceptionTest extends \PHPUnit_Framework_TestCase
     {
     	$this->assertEquals('http://testURL', $this->object->getUrl());
     }
-    
+
     /**
      * @test
      */
  	public function testGetData()
     {
-    	$this->assertEquals('response payload for connection', $this->object->getData());    	
+    	$this->assertEquals('response payload for connection', $this->object->getData());
     }
 }
 ?>

--- a/tests/PPConnectionManagerTest.php
+++ b/tests/PPConnectionManagerTest.php
@@ -2,11 +2,12 @@
 use PayPal\Core\PPConnectionManager;
 use PayPal\Core\PPHttpConnection;
 use PayPal\Core\PPHttpConfig;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPConnectionManager.
  *
  */
-class PPConnectionManagerTest extends \PHPUnit_Framework_TestCase
+class PPConnectionManagerTest extends TestCase
 {
     /**
      * @var PPConnectionManager

--- a/tests/PPCredentialManagerTest.php
+++ b/tests/PPCredentialManagerTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPCredentialManager;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPCredentialManager.
  *
  */
-class PPCredentialManagerTest extends \PHPUnit_Framework_TestCase
+class PPCredentialManagerTest extends TestCase
 {
 	/**
 	 * @var PPCredentialManager

--- a/tests/PPHttpConfigTest.php
+++ b/tests/PPHttpConfigTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPHttpConfig;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPAPIService.
  *
  */
-class PPHttpConfigTest extends PHPUnit_Framework_TestCase
+class PPHttpConfigTest extends TestCase
 {
 
     protected $object;

--- a/tests/PPIPNMessageTest.php
+++ b/tests/PPIPNMessageTest.php
@@ -1,17 +1,18 @@
 <?php
 use PayPal\IPN\PPIPNMessage;
 use PayPal\Core\PPConstants;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPIPNMessage.
  *
  */
-class PPIPNMessageTest extends \PHPUnit_Framework_TestCase {
+class PPIPNMessageTest extends TestCase {
 	/**
 	 * @test
 	 */
-	
+
 	public function passGoodIPN() {
-		
+
 	}
 
 	/**
@@ -36,35 +37,35 @@ class PPIPNMessageTest extends \PHPUnit_Framework_TestCase {
 		$ipn = new PPIPNMessage($ipnData, array('mode' => 'sandbox'));
 		$this->assertEquals(123, $ipn->getTransactionId());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function processIPNWithArrayElements() {
 		$ipnData = 'transaction[0].id=6WM123443434&transaction[0].status=Completed&transaction[1].id=2F12129812A1&transaction[1].status=Pending';
 		$ipn = new PPIPNMessage($ipnData);
-		
+
 		$rawData = $ipn->getRawData();
 		$this->assertEquals(4, count($rawData));
 		$this->assertEquals('6WM123443434', $rawData['transaction[0].id']);
 	}
-	
+
 	/**
 	 * @test
-	 */	
+	 */
 	public function processIPNWithSpecialCharacters() {
 		$ipnData = "description=Jake's store";
-		
+
 		ini_set('get_magic_quotes_gpc', true);
 		$ipn = new PPIPNMessage($ipnData);
-		$rawData = $ipn->getRawData();		
+		$rawData = $ipn->getRawData();
 		$this->assertEquals($rawData['description'], "Jake's store");
-		
+
 		ini_set('get_magic_quotes_gpc', false);
 		$ipn = new PPIPNMessage($ipnData);
 		$rawData = $ipn->getRawData();
 		$this->assertEquals($rawData['description'], "Jake's store");
 		$this->assertEquals($rawData['description'], "Jake's store");
 	}
-	
+
 }

--- a/tests/PPInvalidCredentialExceptionTest.php
+++ b/tests/PPInvalidCredentialExceptionTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Exception\PPInvalidCredentialException;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPInvalidCredentialException.
  *
  */
-class PPInvalidCredentialExceptionTest extends \PHPUnit_Framework_TestCase
+class PPInvalidCredentialExceptionTest extends TestCase
 {
     /**
      * @var PPInvalidCredentialException

--- a/tests/PPLoggingManagerTest.php
+++ b/tests/PPLoggingManagerTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPLoggingManager;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPLoggingManager.
  *
  */
-class PPLoggingManagerTest extends \PHPUnit_Framework_TestCase
+class PPLoggingManagerTest extends TestCase
 {
     /**
      * @var PPLoggingManager

--- a/tests/PPMessageTest.php
+++ b/tests/PPMessageTest.php
@@ -1,6 +1,7 @@
 <?php
 use PayPal\Core\PPMessage;
 use PayPal\Core\PPUtils;
+use PHPUnit\Framework\TestCase;
 
 class SimpleTestClass extends PPMessage {
 	/**
@@ -9,7 +10,7 @@ class SimpleTestClass extends PPMessage {
 	 * @var string
 	 */
 	public $field1;
-	
+
 	/**
 	 *
 	 * @access public
@@ -19,34 +20,34 @@ class SimpleTestClass extends PPMessage {
 }
 
 class SimpleContainerTestClass extends PPMessage {
-	
+
 	/**
 	 * @access public
 	 * @var string
 	 */
 	public $field1;
-	
+
 	/**
 	 * @array
 	 * @access public
 	 * @var string
 	 */
 	public $list1;
-	
+
 	/**
 	 * @array
 	 * @access public
 	 * @var SimpleTestClass
 	 */
 	public $list2;
-	
+
 	/**
 	 * @array
 	 * @access public
 	 * @var AttributeTestClass
 	 */
 	public $list3;
-	
+
 	/**
 	 * @access public
 	 * @var SimpleTestClass
@@ -55,7 +56,7 @@ class SimpleContainerTestClass extends PPMessage {
 }
 
 class AttributeTestClass extends PPMessage {
-	
+
 	/**
 	 *
 	 * @access public
@@ -71,7 +72,7 @@ class AttributeTestClass extends PPMessage {
 	 * @var string
 	 */
 	public $attrib2;
-	
+
 	/**
 	 *
 	 * @access public
@@ -79,7 +80,7 @@ class AttributeTestClass extends PPMessage {
 	 * @var string
 	 */
 	public $value;
-	
+
 }
 
 /**
@@ -93,13 +94,13 @@ class AttributeContainerTestClass extends PPMessage {
 	 * @var AttributeTestClass
 	 */
 	public $member;
-	
+
 		/**
-	 * 
+	 *
      * @array
 	 * @access public
 	 * @var AttributeTestClass
-	 */ 
+	 */
 	public $arrayMember;
 
 }
@@ -109,23 +110,23 @@ class AttributeContainerTestClass extends PPMessage {
  * Test class for PPMessage.
  *
  */
-class PPMessageTest extends PHPUnit_Framework_TestCase
+class PPMessageTest extends TestCase
 {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
-		
+
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
 	 */
 	protected function tearDown() {
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -135,17 +136,17 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 		$o->attrib2 = "random value";
 		$c = new AttributeContainerTestClass();
 		$c->member = $o;
-		
-		$this->assertEquals("attrib1=abc&attrib2=random+value", $o->toNVPString());		
-		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value", $c->toNVPString());		
-		
+
+		$this->assertEquals("attrib1=abc&attrib2=random+value", $o->toNVPString());
+		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value", $c->toNVPString());
+
 		$o->value = "value";
 		$this->assertEquals("attrib1=abc&attrib2=random+value&=value", $o->toNVPString());
 		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value&member=value", $c->toNVPString());
 
-				
+
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -154,73 +155,73 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 		$o->attrib1 = "abc";
 		$o->attrib2 = "random value";
 		$o->value = "value";
-		
+
 		$c = new AttributeContainerTestClass();
 		$c->member = $o;
-		
+
 		$o = new AttributeTestClass();
 		$o->attrib1 = "abc";
 		$o->attrib2 = "random value";
 		$c->arrayMember = array($o);
-		
-		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value&member=value&arrayMember(0).attrib1=abc&arrayMember(0).attrib2=random+value", 
+
+		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value&member=value&arrayMember(0).attrib1=abc&arrayMember(0).attrib2=random+value",
 				$c->toNVPString());
-		
+
 		$c->arrayMember[0]->value = "value";
 		$this->assertEquals("member.attrib1=abc&member.attrib2=random+value&member=value&arrayMember(0).attrib1=abc&arrayMember(0).attrib2=random+value&arrayMember(0)=value",
 				$c->toNVPString());
-		
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function attributeDeserialization() {
-		
+
 		// Attributes and value present
 		$responseMap = array(
 			"member.attrib1" => "abc",
 			"member.attrib2" => "random+value",
 			"member" => "value"
-		);	
+		);
 		$c = new AttributeContainerTestClass();
 		$c->init($responseMap);
-		
+
 		$this->assertNotNull($c->member);
 		$this->assertEquals("abc", $c->member->attrib1);
 		$this->assertEquals("random value", $c->member->attrib2);
 		$this->assertEquals("value", $c->member->value);
 
-		// Only value present		
+		// Only value present
 		$responseMap = array(
 			"member" => "value"
-		);		
+		);
 		$c = new AttributeContainerTestClass();
 		$c->init($responseMap);
-		
+
 		$this->assertNotNull($c->member);
 		$this->assertEquals("value", $c->member->value);
-		
 
-		// Only attributes present		
+
+		// Only attributes present
 		$responseMap = array(
 			"member.attrib1" => "abc",
 			"member.attrib2" => "random+value"
 		);
 		$c = new AttributeContainerTestClass();
 		$c->init($responseMap);
-		
+
 		$this->assertNotNull($c->member);
 		$this->assertEquals("abc", $c->member->attrib1);
-		$this->assertEquals("random value", $c->member->attrib2);		
-	
+		$this->assertEquals("random value", $c->member->attrib2);
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function attributeDeserializationInArrays() {
-	
+
 		// Only value present. Single item in list
 		$responseMap = array(
 				"arrayMember(0)" => "value+1"
@@ -229,21 +230,21 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 		$c->init($responseMap);
 		$this->assertNotNull($c->arrayMember[0]);
 		$this->assertEquals("value 1", $c->arrayMember[0]->value);
-		
-		
+
+
 		// Only attributes present. Single item in list
 		$responseMap = array(
 			"arrayMember(0).attrib1" => "abc",
-			"arrayMember(0).attrib2" => "random+value",				
+			"arrayMember(0).attrib2" => "random+value",
 		);
 		$c = new AttributeContainerTestClass();
 		$c->init($responseMap);
-		
+
 		$this->assertNotNull($c->arrayMember[0]);
 		$this->assertEquals("abc", $c->arrayMember[0]->attrib1);
-		$this->assertEquals("random value", $c->arrayMember[0]->attrib2);		
-		
-		
+		$this->assertEquals("random value", $c->arrayMember[0]->attrib2);
+
+
 		// Attributes and value present. Mulitple items in list
 		$responseMap = array(
 			"arrayMember(0).attrib1" => "abc",
@@ -257,10 +258,10 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals("value", $c->arrayMember[0]->value);
 		$this->assertEquals("xyz", $c->arrayMember[0]->attrib1);
 		$this->assertEquals("random value", $c->arrayMember[0]->attrib2);
-		
+
 		$this->assertEquals("attribute1", $c->arrayMember[1]->attrib1);
 		$this->assertNull($c->arrayMember[1]->value);
-		
+
 	}
 
 
@@ -268,60 +269,60 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 	 * @test
 	 */
 	public function simpleSerialization() {
-		
+
 		$o = new SimpleTestClass();
 		$o->field1 = "fieldvalue1";
 		$o->field2 = "fieldvalue2";
-		
+
 		$this->assertEquals("field1=fieldvalue1&field2=fieldvalue2", $o->toNVPString(''));
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function simpleDeserialization() {
-	
+
 		$map = array(
 			"field1" => "fieldvalue1",
 			"field2" => "field+value2"
 		);
 		$o = new SimpleTestClass();
 		$o->init($map);
-	
+
 		$this->assertEquals("fieldvalue1", $o->field1);
 		$this->assertEquals("field value2", $o->field2);
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function nestedSerialization() {
-	
+
 		$o = new SimpleTestClass();
 		$o->field1 = "fieldvalue1";
 		$o->field2 = "fieldvalue2";
-	
+
 		$c = new SimpleContainerTestClass();
 		$c->nestedField = $o;
 		$c->field1 = "abc";
-	
+
 		$this->assertEquals("field1=abc&nestedField.field1=fieldvalue1&nestedField.field2=fieldvalue2", $c->toNVPString(''));
 	}
 
-	
+
 	/**
 	 * @test
 	 */
 	public function nestedDeserialization() {
-		
+
 		$map = array(
 			"field1" => "abc",
 			"nestedField.field1" => "fieldvalue1",
 			"nestedField.field2" => "field+value2"
 		);
-	
+
 		$c = new SimpleContainerTestClass();
 		$c->init($map);
 
@@ -329,113 +330,113 @@ class PPMessageTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals("fieldvalue1", $c->nestedField->field1);
 		$this->assertEquals("field value2", $c->nestedField->field2);
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function simpleListSerialization() {
-	
+
 		$c = new SimpleContainerTestClass();
 		$c->list1 = array('Array', "of", "some strings");
 		$c->field1 = "abc";
-	
+
 		$this->assertEquals("field1=abc&list1(0)=Array&list1(1)=of&list1(2)=some+strings", $c->toNVPString(''));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function simpleListDeserialization() {
-	
+
 		$map = array(
 			"field1" => "abc",
 			"list1(0)" => "Array",
 			"list1(1)" => "of",
 			"list1(2)" => "some+strings"
 		);
-				
+
 		$c = new SimpleContainerTestClass();
 		$c->init($map);
-	
+
 		$this->assertEquals("abc", $c->field1);
 		$this->assertEquals(3, count($c->list1));
 		$this->assertEquals("some strings", $c->list1[2]);
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function complexListSerialization() {
-	
+
 		$o1 = new SimpleTestClass();
 		$o1->field1 = "somevalue1";
 		$o1->field2 = "somevalue2";
-	
+
 		$o2 = new SimpleTestClass();
 		$o2->field1 = "another value1";
 		$o2->field2 = "anothervalue2";
-		
+
 		$c = new SimpleContainerTestClass();
 		$c->list2 = array($o1, $o2);
-	
-		$this->assertEquals("list2(0).field1=somevalue1&list2(0).field2=somevalue2&list2(1).field1=another+value1&list2(1).field2=anothervalue2", 
+
+		$this->assertEquals("list2(0).field1=somevalue1&list2(0).field2=somevalue2&list2(1).field1=another+value1&list2(1).field2=anothervalue2",
 				$c->toNVPString(''));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function complexListDeserialization() {
-		
+
 		$map = array(
 			"list2(0).field1" => "somevalue1",
 			"list2(0).field2" => "somevalue2",
 			"list2(1).field1" => "another+value1",
 			"list2(1).field2" => "anothervalue2"
 		);
-		
+
 		$c = new SimpleContainerTestClass();
 		$c->init($map);
-	
+
 		$this->assertEquals(2, count($c->list2));
 		$this->assertEquals("somevalue1", $c->list2[0]->field1);
 		$this->assertEquals("another value1", $c->list2[1]->field1);
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function serializeAndDeserialize() {
-		
+
 		$o1 = new AttributeTestClass();
 		$o1->value = "some value";
 		$o1->attrib1 = "someattrib";
-		
+
 		$o2 = new AttributeTestClass();
 		$o2->value = "some value2";
-		
+
 		$o3 = new AttributeTestClass();
 		$o3->attrib1 = "attribute";
 		$o3->value = "some value3";
-		
+
 		$c = new SimpleContainerTestClass();
 		$c->list3 = array($o1, $o2, $o3);
-		
+
 		$newC = new SimpleContainerTestClass();
 		$newC->init(PPUtils::nvpToMap($c->toNVPString(''))); //TODO: Mock nvpToMap
-		
+
 		$this->assertEquals($c, $newC);
 	}
 
 	/**
 	 * @test
 	 */
-	public function deserializeAndSerialize() {		
+	public function deserializeAndSerialize() {
 		$nvpString = "list2(0).field1=somevalue1&list2(0).field2=somevalue2&list2(1).field1=another+value1&list2(1).field2=anothervalue2&list3(0).attrib1=somevalue1&list3(0).attrib2=somevalue2&list3(0)=value+field&list3(1).attrib1=another+value1&list3(2)=anothervalue2";
 		$newC = new SimpleContainerTestClass();
-		$newC->init(PPUtils::nvpToMap($nvpString)); //TODO: Mock nvpToMap		
+		$newC->init(PPUtils::nvpToMap($nvpString)); //TODO: Mock nvpToMap
 		$this->assertEquals($nvpString, $newC->toNVPString());
 	}
 }

--- a/tests/PPMissingCredentialExceptionTest.php
+++ b/tests/PPMissingCredentialExceptionTest.php
@@ -1,11 +1,11 @@
 <?php
 use PayPal\Exception\PPMissingCredentialException;
-
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPMissingCredentialException.
  *
  */
-class PPMissingCredentialExceptionTest extends \PHPUnit_Framework_TestCase
+class PPMissingCredentialExceptionTest extends TestCase
 {
     /**
      * @var PPMissingCredentialException

--- a/tests/PPModelTest.php
+++ b/tests/PPModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PayPal\Common\PPModel;
+use PHPUnit\Framework\TestCase;
 
 class SimpleModelTestClass extends PPModel {
 	/**
@@ -12,7 +13,7 @@ class SimpleModelTestClass extends PPModel {
 		$this->field1 = $field1;
 		return $this;
 	}
-	
+
 	/**
 	 *
 	 * @access public
@@ -21,7 +22,7 @@ class SimpleModelTestClass extends PPModel {
 	public function getField1() {
 		return $this->field1;
 	}
-	
+
 	/**
 	 *
 	 * @access public
@@ -31,7 +32,7 @@ class SimpleModelTestClass extends PPModel {
 		$this->field2 = $field2;
 		return $this;
 	}
-	
+
 	/**
 	 *
 	 * @access public
@@ -40,7 +41,7 @@ class SimpleModelTestClass extends PPModel {
 	public function getField2() {
 		return $this->field2;
 	}
-	
+
 }
 
 
@@ -134,23 +135,23 @@ class ListModelTestClass extends PPModel {
  * Test class for PPModel.
  *
  */
-class PPModelTest extends PHPUnit_Framework_TestCase
+class PPModelTest extends TestCase
 {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
-		
+
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
 	 */
 	protected function tearDown() {
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -158,15 +159,15 @@ class PPModelTest extends PHPUnit_Framework_TestCase
 		$o = new SimpleModelTestClass();
 		$o->setField1('value 1');
 		$o->setField2("value 2");
-		
+
 		$this->assertEquals('{"field1":"value 1","field2":"value 2"}', $o->toJSON());
-		
+
 		$oCopy = new SimpleModelTestClass();
-		$oCopy->fromJson($o->toJSON());		
+		$oCopy->fromJson($o->toJSON());
 		$this->assertEquals($o, $oCopy);
-				
+
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -174,16 +175,16 @@ class PPModelTest extends PHPUnit_Framework_TestCase
 		$o = new SimpleModelTestClass();
 		$o->setField1('value "1');
 		$o->setField2("value 2");
-	
+
 		$this->assertEquals('{"field1":"value \"1","field2":"value 2"}', $o->toJSON());
-	
+
 		$oCopy = new SimpleModelTestClass();
 		$oCopy->fromJson($o->toJSON());
 		$this->assertEquals($o, $oCopy);
-	
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
@@ -191,38 +192,38 @@ class PPModelTest extends PHPUnit_Framework_TestCase
 		$child = new SimpleModelTestClass();
 		$child->setField1('value 1');
 		$child->setField2("value 2");
-		
+
 		$parent = new ContainerModelTestClass();
 		$parent->setField1("parent");
 		$parent->setNested1($child);
-	
-		$this->assertEquals('{"field1":"parent","nested1":{"field1":"value 1","field2":"value 2"}}', 
+
+		$this->assertEquals('{"field1":"parent","nested1":{"field1":"value 1","field2":"value 2"}}',
 				$parent->toJSON());
-	
+
 		$parentCopy = new ContainerModelTestClass();
 		$parentCopy->fromJson($parent->toJSON());
 		$this->assertEquals($parent, $parentCopy);
-	
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function testListConversion() {
 		$c1 = new SimpleModelTestClass();
 		$c1->setField1("a")->setField2('value');
-		
+
 		$c2 = new SimpleModelTestClass();
 		$c1->setField1("another")->setField2('object');
-		
+
 		$parent = new ListModelTestClass();
 		$parent->setList1(array('simple', 'list', 'with', 'integer', 'keys'));
 		$parent->setList2(array($c1, $c2));
-		
+
 		$parentCopy = new ListModelTestClass();
 		$parentCopy->fromJson($parent->toJSON());
 		$this->assertEquals($parent, $parentCopy);
-	
+
 	}
 }

--- a/tests/PPSignatureCredentialTest.php
+++ b/tests/PPSignatureCredentialTest.php
@@ -2,11 +2,12 @@
 use PayPal\Auth\PPSignatureCredential;
 use PayPal\Auth\PPTokenAuthorization;
 use PayPal\Auth\PPSubjectAuthorization;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPSignatureCredential.
  *
  */
-class PPSignatureCredentialTest extends PHPUnit_Framework_TestCase
+class PPSignatureCredentialTest extends TestCase
 {
 	/**
 	 * @var PPSignatureCredential
@@ -83,14 +84,14 @@ class PPSignatureCredentialTest extends PHPUnit_Framework_TestCase
 	{
 		$this->assertEquals('APP-80W284485P519543T', $this->platformCredential->getApplicationId());
 	}
-	
+
 	public function testThirdPartyAuthorization() {
 		$authorizerEmail = "merchant@domain.com";
-		$thirdPartyAuth = new PPSubjectAuthorization($authorizerEmail);		
+		$thirdPartyAuth = new PPSubjectAuthorization($authorizerEmail);
 		$cred = new PPSignatureCredential("username", "pwd", "signature");
-		$cred->setThirdPartyAuthorization($thirdPartyAuth);		
+		$cred->setThirdPartyAuthorization($thirdPartyAuth);
 		$this->assertEquals($cred->getThirdPartyAuthorization()->getSubject(), $authorizerEmail);
-		
+
 		$accessToken = "atoken";
 		$tokenSecret = "asecret";
 		$thirdPartyAuth = new PPTokenAuthorization($accessToken, $tokenSecret);

--- a/tests/PPUtilsTest.php
+++ b/tests/PPUtilsTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPUtils;
+use PHPUnit\Framework\TestCase;
 /**
  * Test class for PPUtils.
  *
  */
-class PPUtilsTest extends \PHPUnit_Framework_TestCase
+class PPUtilsTest extends TestCase
 {
     /**
      * @var PPUtils
@@ -46,10 +47,10 @@ class PPUtilsTest extends \PHPUnit_Framework_TestCase
     {
 	$arr = array('key1' => 'somevalue', 'key2' => 'someothervalue');
 	$this->assertEquals(true, PPUtils::array_match_key($arr, "key"));
-		
+
 		$arr = array('key1' => 'somevalue', 'key2' => 'someothervalue');
 		$this->assertEquals(false, PPUtils::array_match_key($arr, "prefix"));
-		
+
 		$arr = unserialize('a:10:{s:26:"responseEnvelope.timestamp";s:35:"2011-04-19T04%3A32%3A29.469-07%3A00";s:20:"responseEnvelope.ack";s:7:"Failure";s:30:"responseEnvelope.correlationId";s:13:"c2514f258ddf1";s:22:"responseEnvelope.build";s:7:"1829457";s:16:"error(0).errorId";s:6:"580027";s:15:"error(0).domain";s:8:"PLATFORM";s:17:"error(0).severity";s:5:"Error";s:17:"error(0).category";s:11:"Application";s:16:"error(0).message";s:44:"Prohibited+request+parameter%3A+businessInfo";s:21:"error(0).parameter(0)";s:12:"businessInfo";}');
 		$this->assertEquals(true, PPUtils::array_match_key($arr, "error(0)."));
     }
@@ -61,7 +62,7 @@ class PPUtilsTest extends \PHPUnit_Framework_TestCase
     {
         $ip = $this->object->getLocalIPAddress();
         $this->assertEquals($ip, filter_var($ip, FILTER_VALIDATE_IP));
-        
+
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
         $ip = $this->object->getLocalIPAddress();
         $this->assertEquals($ip, filter_var($ip, FILTER_VALIDATE_IP));
@@ -81,22 +82,22 @@ class PPUtilsTest extends \PHPUnit_Framework_TestCase
 		. '</SOAP-ENV:Body></SOAP-ENV:Envelope>';
 
     	$ret = PPUtils::xmlToArray($xml);
-    	
+
         $this->assertEquals("SetExpressCheckoutResponse", $ret[0]['name']);
 
         $ret = $ret[0]['children'];
     	$this->assertEquals(6, count($ret));
-    	
+
 	// Token node
     	$this->assertFalse(array_key_exists('children', $ret[5]));
     	$this->assertEquals("Token", $ret[5]['name']);
     	$this->assertEquals("EC-6KT84265CE1992425", $ret[5]['text']);
-    	
+
     	$this->assertEquals(1, count($ret[5]['attributes']));
     	$k = key($ret[5]['attributes']);
     	$this->assertEquals("attrib", $k);
     	$this->assertEquals("someValue", $ret[5]['attributes'][$k]);
-    	
+
     	// Ack Node
     	$this->assertEquals("Ack", $ret[1]['name']);
     	$this->assertEquals(1, count($ret[1]['children']));
@@ -127,7 +128,7 @@ class PPUtilsTest extends \PHPUnit_Framework_TestCase
     	$this->assertEquals('fieldWithSpecialChar', $ret['fieldwith-specialchar']);
 
     }
-    
+
     /**
      * @test
      */
@@ -139,7 +140,7 @@ class PPUtilsTest extends \PHPUnit_Framework_TestCase
     	$this->assertEquals(true, PPUtils::isPropertyArray('MockReflectionTestType', 'arrayMember'));
     	$this->assertEquals(false, PPUtils::isPropertyArray('MockReflectionTestType', 'value'));
     }
-    
+
     /**
      * @test
      */

--- a/tests/PPXMLMessageTest.php
+++ b/tests/PPXMLMessageTest.php
@@ -2,6 +2,7 @@
 use PayPal\Core\PPXmlFaultMessage;
 use PayPal\Core\PPXmlMessage;
 use PayPal\Core\PPUtils;
+use PHPUnit\Framework\TestCase;
 
 class SimpleXMLTestClass extends PPXmlMessage {
 	/**
@@ -11,7 +12,7 @@ class SimpleXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $field1;
-	
+
 	/**
 	 *
 	 * @access public
@@ -19,7 +20,7 @@ class SimpleXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $field2;
-	
+
 	/**
 	 * @name fieldWith-FunnyName
 	 * @access public
@@ -30,14 +31,14 @@ class SimpleXMLTestClass extends PPXmlMessage {
 }
 
 class SimpleContainerXMLTestClass extends PPXmlMessage {
-	
+
 	/**
 	 * @access public
 	 * @namespace ebl
 	 * @var string
 	 */
 	public $field1;
-	
+
 	/**
 	 * @array
 	 * @access public
@@ -45,7 +46,7 @@ class SimpleContainerXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $list1;
-	
+
 	/**
 	 * @array
 	 * @access public
@@ -53,7 +54,7 @@ class SimpleContainerXMLTestClass extends PPXmlMessage {
 	 * @var SimpleXMLTestClass
 	 */
 	public $list2;
-	
+
 	/**
 	 * @array
 	 * @access public
@@ -61,7 +62,7 @@ class SimpleContainerXMLTestClass extends PPXmlMessage {
 	 * @var AttributeXMLTestClass
 	 */
 	public $list3;
-	
+
 	/**
 	 * @access public
 	 * @namespace ebl
@@ -71,7 +72,7 @@ class SimpleContainerXMLTestClass extends PPXmlMessage {
 }
 
 class AttributeXMLTestClass extends PPXmlMessage {
-	
+
 	/**
 	 *
 	 * @access public
@@ -87,7 +88,7 @@ class AttributeXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $attrib2;
-	
+
 	/**
 	 *
 	 * @access public
@@ -96,11 +97,11 @@ class AttributeXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $value;
-	
+
 }
 
 class AttributeComplexXMLTestClass extends PPXmlMessage {
-	
+
 	/**
 	 *
 	 * @access public
@@ -116,21 +117,21 @@ class AttributeComplexXMLTestClass extends PPXmlMessage {
 	 * @var string
 	 */
 	public $attrib2;
-	
+
 	/**
 	 *
 	 * @access public
 	 * @var string
 	 */
 	public $value1;
-	
+
 	/**
 	 *
 	 * @access public
 	 * @var string
 	 */
 	public $value2;
-	
+
 }
 
 
@@ -146,14 +147,14 @@ class AttributeContainerXMLTestClass extends PPXmlMessage {
 	 * @var AttributeXMLTestClass
 	 */
 	public $member;
-	
+
 		/**
-	 * 
+	 *
      * @array
 	 * @access public
 	 * @namespace ebl
 	 * @var AttributeXMLTestClass
-	 */ 
+	 */
 	public $arrayMember;
 
 }
@@ -332,24 +333,24 @@ class ErrorParameter extends PPXmlMessage {
  * Test class for PPXmlMessage.
  *
  */
-class PPXmlMessageTest extends PHPUnit_Framework_TestCase
+class PPXmlMessageTest extends TestCase
 {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
-		
+
 	}
-	
+
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
 	 */
 	protected function tearDown() {
 	}
-	
-	
+
+
 	private function wrapInSoapMessage($str) {
 		$str = '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">'
 			. '<SOAP-ENV:Body id="_0">'
@@ -365,62 +366,62 @@ class PPXmlMessageTest extends PHPUnit_Framework_TestCase
 		$o = new SimpleXMLTestClass();
 		$o->field1 = "fieldvalue1";
 		$o->field2 = "fieldvalue2";
-		
+
 		$this->assertEquals($o->toXMLString(), $o->toSOAP());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSimpleSerialization() {
-		
+
 		$o = new SimpleXMLTestClass();
 		$o->field1 = "fieldvalue1";
 		$o->field2 = "fieldvalue2";
 
 		$this->assertEquals("<ebl:field1>fieldvalue1</ebl:field1><ebl:field2>fieldvalue2</ebl:field2>", $o->toXMLString(''));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSpecialCharsSerialization() {
-	
+
 		$o = new SimpleXMLTestClass();
 		$o->field1 = "fieldvalue1";
 		$o->fieldWithFunnyName = "fieldvalue2";
-	
+
 		$this->assertEquals("<ebl:field1>fieldvalue1</ebl:field1><ebl:fieldWith-FunnyName>fieldvalue2</ebl:fieldWith-FunnyName>", $o->toXMLString(''));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testNestedSerialization() {
-	
+
 		$child = new SimpleXMLTestClass();
 		$child->field1 = "fieldvalue1";
 		$child->field2 = "fieldvalue2";
-		
+
 		$parent = new SimpleContainerXMLTestClass();
 		$parent->field1 = 'parent';
 		$parent->nestedField = $child;
-		
-		
+
+
 		$this->assertEquals("<ebl:field1>parent</ebl:field1><ebl:nestedField><ebl:field1>fieldvalue1</ebl:field1><ebl:field2>fieldvalue2</ebl:field2></ebl:nestedField>", $parent->toXMLString(''));
 	}
-	
+
 	/**
 	 * @test
 	 */
-	public function testListSerialization() {	
-		
+	public function testListSerialization() {
+
 		$parent = new SimpleContainerXMLTestClass();
-		$parent->list1 = array('i', 'am', 'an array');	
-		
+		$parent->list1 = array('i', 'am', 'an array');
+
 		$this->assertEquals('<ebl:list1>i</ebl:list1><ebl:list1>am</ebl:list1><ebl:list1>an array</ebl:list1>', $parent->toXMLString(''));
-		
-		
+
+
 		$child1 = new SimpleXMLTestClass();
 		$child1->field1 = "c1v1";
 		$child1->field2 = "c1v2";
@@ -428,7 +429,7 @@ class PPXmlMessageTest extends PHPUnit_Framework_TestCase
 		$child2->field1 = "c2v1";
 		$child2->field2 = "c2v2";
 		$parent->list2 = array($child1, $child2);
-		
+
 		$this->assertEquals('<ebl:list1>i</ebl:list1><ebl:list1>am</ebl:list1><ebl:list1>an array</ebl:list1>'
 				. '<ebl:list2><ebl:field1>c1v1</ebl:field1><ebl:field2>c1v2</ebl:field2></ebl:list2>'
 				. '<ebl:list2><ebl:field1>c2v1</ebl:field1><ebl:field2>c2v2</ebl:field2></ebl:list2>'
@@ -439,120 +440,120 @@ class PPXmlMessageTest extends PHPUnit_Framework_TestCase
 	 * @test
 	 */
 	public function testAttributeSerialization() {
-	
+
 		$o = new AttributeXMLTestClass();
 		$o->attrib1 = "a value";
 		$o->attrib2 = "another value";
 		$o->value = "value";
-		
+
 		$this->assertEquals('attrib1="a value" attrib2="another value">value', $o->toXMLString(''));
-		
-	
-		$o = new AttributeXMLTestClass();		
+
+
+		$o = new AttributeXMLTestClass();
 		$o->value = "value";
-		
+
 		$this->assertEquals(' >value', $o->toXMLString(''));
-		
+
 		$o = new AttributeXMLTestClass();
 		$o->attrib1 = "a value";
 		$o->attrib2 = "another value";
-		
+
 		$this->assertEquals('attrib1="a value" attrib2="another value">', $o->toXMLString(''));
 
 		$o = new AttributeXMLTestClass();
 		$o->attrib1 = "a value";
 		$o->attrib2 = "another value";
 		$o->value = "value";
-		
+
 		$this->assertEquals('attrib1="a value" attrib2="another value">value', $o->toXMLString());
-		
+
 		$o = new AttributeComplexXMLTestClass();
 		$o->attrib1 = "a value";
 		$o->attrib2 = "another value";
 		$o->value1 = "value1";
 		$o->value2 = "value2";
-		
+
 		$this->assertEquals('attrib1="a value" attrib2="another value"><ebl:value1>value1</ebl:value1><ebl:value2>value2</ebl:value2>', $o->toXMLString());
 
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSimpleDeserialization() {
-		
+
 		$str = $this->wrapInSoapMessage("<SimpleXMLTestClass><field1>fieldvalue1</field1><field2>0</field2></SimpleXMLTestClass>");
-		
+
 		$o = new SimpleXMLTestClass();
 		$o->init($str);
-		
+
 		$this->assertEquals("fieldvalue1", $o->field1);
 		$this->assertSame("0", $o->field2);
 
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSpecialCharsDeserialization() {
-	
+
 		$str = $this->wrapInSoapMessage("<SimpleXMLTestClass><field1>fieldvalue1</field1><fieldWith-FunnyName>fieldvalue2</fieldWith-FunnyName></SimpleXMLTestClass>");
 		$o = new SimpleXMLTestClass();
 		$o->init($str);
-		
+
 		$this->assertEquals('fieldvalue1', $o->field1);
 		$this->assertEquals('fieldvalue2', $o->fieldWithFunnyName);
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testAttributeDeserialization() {
-	
+
 		$str = $this->wrapInSoapMessage('<AttributeContainerXMLTestClass><member attrib1="a value" attrib2="another value">value</member></AttributeContainerXMLTestClass>');
 		$o = new AttributeContainerXMLTestClass();
 		$o->init($str);
-	
+
 		$this->assertNotNull($o->member);
 		$this->assertEquals("value", $o->member->value);
 		$this->assertEquals("a value", $o->member->attrib1);
 		$this->assertEquals("another value", $o->member->attrib2);
-		
-		
+
+
 		$str = $this->wrapInSoapMessage('<AttributeContainerXMLTestClass><member>value</member></AttributeContainerXMLTestClass>');
 		$o = new AttributeContainerXMLTestClass();
-		$o->init($str);		
-		
+		$o->init($str);
+
 		$this->assertNotNull($o->member);
 // 		$this->assertEquals("value", $o->member->value);
 // 		$this->assertNull($o->member->attrib1);
 // 		$this->assertNull($o->member->attrib2);
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testListDeserialization() {
-		
-		
-		
+
+
+
 		$str = $this->wrapInSoapMessage('<SimpleContainerXMLTestClass><list1>i</list1><list1>am</list1><list1>an array</list1></SimpleContainerXMLTestClass>');
 		$parent = new SimpleContainerXMLTestClass();
 		$parent->init($str);
-		
+
 		$this->assertNotNull($parent->list1);
  		$this->assertEquals(true, is_array($parent->list1));
  		$this->assertEquals(3, count($parent->list1));
  		$this->assertEquals('an array', $parent->list1[2]);
-		
-		
+
+
 		$str = $this->wrapInSoapMessage('<SimpleContainerXMLTestClass><list1>i</list1><list1>am</list1><list1>an array</list1>'
 				. '<list2><field1>c1v1</field1><field2>c1v2</field2></list2>'
 				. '<list2><field1>c2v1</field1><field2>c2v2</field2></list2></SimpleContainerXMLTestClass>');
 		$parent = new SimpleContainerXMLTestClass();
 		$parent->init($str);
-		
+
 		$this->assertNotNull($parent->list2);
 		$this->assertEquals(true, is_array($parent->list2));
 		$this->assertEquals(2, count($parent->list2));
@@ -560,24 +561,24 @@ class PPXmlMessageTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('c1v2', $parent->list2[0]->field2);
 		$this->assertEquals('c2v1', $parent->list2[1]->field1);
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testNestedDeserialization() {
-		
+
 		$str = $this->wrapInSoapMessage("<SimpleContainerXMLTestClass><field1>parent</field1><nestedField><field1>fieldvalue1</field1><field2>fieldvalue2</field2></nestedField></SimpleContainerXMLTestClass>");
 		$o = new SimpleContainerXMLTestClass();
 		$o->init($str);
-		
+
 		$this->assertEquals("parent", $o->field1);
 		$this->assertNotNull($o->nestedField);
 		$this->assertEquals("fieldvalue1", $o->nestedField->field1);
 		$this->assertEquals("fieldvalue2", $o->nestedField->field2);
-		
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
@@ -588,9 +589,9 @@ class PPXmlMessageTest extends PHPUnit_Framework_TestCase
 
 		$o = new FaultMessage();
 		$o->init($map, false);
-		
+
 		$this->assertEquals("Failure", $o->responseEnvelope->ack);
 		$this->assertEquals("Application", $o->error[0]->category);
 	}
-	
+
 }

--- a/tests/formatters/FormatterFactoryTest.php
+++ b/tests/formatters/FormatterFactoryTest.php
@@ -1,7 +1,8 @@
 <?php
 use PayPal\Formatter\FormatterFactory;
-class FormatterFactoryTest extends PHPUnit_Framework_TestCase {
-	
+use PHPUnit\Framework\TestCase;
+class FormatterFactoryTest extends TestCase {
+
 	/**
 	 * @test
 	 */
@@ -9,7 +10,7 @@ class FormatterFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('PayPal\Formatter\PPNVPFormatter', get_class(FormatterFactory::factory('NV')));
 		$this->assertEquals('PayPal\Formatter\PPSOAPFormatter', get_class(FormatterFactory::factory('SOAP')));
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/formatters/PPNVPFormatterTest.php
+++ b/tests/formatters/PPNVPFormatterTest.php
@@ -1,10 +1,11 @@
 <?php
 use PayPal\Core\PPRequest;
 use PayPal\Formatter\PPNVPFormatter;
-class PPNVPFormatterTest extends PHPUnit_Framework_TestCase {
-	
+use PHPUnit\Framework\TestCase;
+class PPNVPFormatterTest extends TestCase {
+
 	private $object;
-	
+
 	public function setup() {
 		$this->object = new PPNVPFormatter();
 	}
@@ -17,7 +18,7 @@ class PPNVPFormatterTest extends PHPUnit_Framework_TestCase {
 				$this->object->toString(new PPRequest($data, 'NVP'))
 		);
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/formatters/PPSOAPFormatterTest.php
+++ b/tests/formatters/PPSOAPFormatterTest.php
@@ -1,21 +1,22 @@
 <?php
 use PayPal\Core\PPRequest;
 use PayPal\Formatter\PPSOAPFormatter;
+use PHPUnit\Framework\TestCase;
 
-class PPSOAPFormatterTest extends PHPUnit_Framework_TestCase {
-	
+class PPSOAPFormatterTest extends TestCase {
+
 	private $object;
-	
+
 	public function setup() {
 		$this->object = new PPSOAPFormatter();
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSimpleSerializationCall() {
 		$data = new MockSOAPObject();
-		
+
 		$expected = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"  ><soapenv:Header></soapenv:Header><soapenv:Body>'
 					. $data->toXMLString()
 					. '</soapenv:Body></soapenv:Envelope>';
@@ -23,21 +24,21 @@ class PPSOAPFormatterTest extends PHPUnit_Framework_TestCase {
 				$this->object->toString(new PPRequest($data, 'SOAP'))
 		);
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testSerializationWithNSCall() {
-		$data = new MockSOAPObject();		
+		$data = new MockSOAPObject();
 		$request = new PPRequest($data, 'SOAP');
 		$request->addBindingInfo("namespace", 'ns="http://myns"');
-		
+
 		$expected = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" ns="http://myns" ><soapenv:Header></soapenv:Header><soapenv:Body>'
 		. $data->toXMLString()
 		. '</soapenv:Body></soapenv:Envelope>';
 		$this->assertEquals($expected, $this->object->toString($request));
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -46,14 +47,14 @@ class PPSOAPFormatterTest extends PHPUnit_Framework_TestCase {
 		$request = new PPRequest($data, 'SOAP');
 		$request->addBindingInfo("namespace", 'ns="http://myns"');
 		$request->addBindingInfo("securityHeader", "<abc><xyz>1</xyz></abc>");
-		
-	
+
+
 		$expected = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" ns="http://myns" ><soapenv:Header><abc><xyz>1</xyz></abc></soapenv:Header><soapenv:Body>'
 		. $data->toXMLString()
 		. '</soapenv:Body></soapenv:Envelope>';
 		$this->assertEquals($expected, $this->object->toString($request));
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/handlers/PPAuthenticationHandlerTest.php
+++ b/tests/handlers/PPAuthenticationHandlerTest.php
@@ -4,39 +4,40 @@ use PayPal\Auth\PPTokenAuthorization;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
 use PayPal\Handler\PPAuthenticationHandler;
+use PHPUnit\Framework\TestCase;
 
-class PPAuthenticationHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPAuthenticationHandlerTest extends TestCase {
+
 	protected function setup() {
-		
+
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testValidConfiguration() {
-		
+
 		$credential = new PPSignatureCredential('user', 'pass', 'sign');
 		$credential->setThirdPartyAuthorization(new PPTokenAuthorization('accessToken', 'tokenSecret'));
 		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'DoExpressCheckout', 'port' => 'PayPalAPI');
-		
+
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$req->setCredential($credential);
-		
+
 		$httpConfig = new PPHttpConfig('http://api.paypal.com');
-		
+
 		$handler = new PPAuthenticationHandler();
-		$handler->handle($httpConfig, $req, $options);		
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertArrayHasKey('X-PP-AUTHORIZATION', $httpConfig->getHeaders());
-		
+
 		$options['port'] = 'abc';
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertArrayHasKey('X-PAYPAL-AUTHORIZATION', $httpConfig->getHeaders());
-		
+
 		unset($options['port']);
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertArrayHasKey('X-PAYPAL-AUTHORIZATION', $httpConfig->getHeaders());

--- a/tests/handlers/PPCertificateAuthHandlerTest.php
+++ b/tests/handlers/PPCertificateAuthHandlerTest.php
@@ -5,111 +5,112 @@ use PayPal\Auth\PPTokenAuthorization;
 use PayPal\Handler\PPCertificateAuthHandler;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
+use PHPUnit\Framework\TestCase;
 
-class PPCertificateAuthHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPCertificateAuthHandlerTest extends TestCase {
+
 	protected function setup() {
-		
+
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAddedForNVP() {
-		
+
 		$req = new PPRequest(new StdClass(), 'NV');
 		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');
-						
+
 		$handler = new PPCertificateAuthHandler();
-		
+
 		// Test that no headers are added if no credential is passed
 		$httpConfig = new PPHttpConfig();
-		$handler->handle($httpConfig, $req, $options);		
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
-		
+
 		// Test that the 3 token headers are added for first party API calls
 		$httpConfig = new PPHttpConfig();
-		$cred = new PPCertificateCredential('user', 'pass', 'cacert.pem');		
+		$cred = new PPCertificateCredential('user', 'pass', 'cacert.pem');
 		$req->setCredential($cred);
-		
-		$handler->handle($httpConfig, $req, $options);		
+
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(2, count($httpConfig->getHeaders()));
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
-		
+
 		// Test addition of 'subject' HTTP header for subject based third party auth
 		$httpConfig = new PPHttpConfig();
 		$cred = new PPCertificateCredential('user', 'pass', 'cacert.pem');
 		$cred->setThirdPartyAuthorization(new PPSubjectAuthorization('email@paypal.com'));
 		$req->setCredential($cred);
-		
+
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(3, count($httpConfig->getHeaders()));
 		$this->assertArrayHasKey('X-PAYPAL-SECURITY-SUBJECT', $httpConfig->getHeaders());
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
-		
-		// Test that no auth related HTTP headers (username, password, sign?) are 
+
+		// Test that no auth related HTTP headers (username, password, sign?) are
 		// added for token based third party auth
 		$httpConfig = new PPHttpConfig();
 		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));
-				
-		$handler->handle($httpConfig, $req, $options);		
+
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
-	
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAddedForSOAP() {
-	
-		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');		
+
+		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');
 		$req = new PPRequest(new StdClass(), 'SOAP');
-		
+
 		$handler = new PPCertificateAuthHandler();
-		
+
 		// Test that no headers are added if no credential is passed
 		$httpConfig = new PPHttpConfig();
 		$handler->handle($httpConfig, $req, $options);
-		$this->assertEquals('', $req->getBindingInfo('securityHeader'));		
-		
+		$this->assertEquals('', $req->getBindingInfo('securityHeader'));
+
 		// Test that the 3 token SOAP headers are added for first party API calls
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$req->setCredential(new PPCertificateCredential('user', 'pass', 'cacert.pem'));
 		$handler->handle($httpConfig, $req, $options);
-		
+
 		$this->assertContains('<ebl:Username>', $req->getBindingInfo('securityHeader'));
-		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));		
+		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
-		
+
 		// Test addition of 'subject' SOAP header for subject based third party auth
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$cred = new PPCertificateCredential('user', 'pass', 'cacert.pem');
 		$cred->setThirdPartyAuthorization(new PPSubjectAuthorization('email@paypal.com'));
 		$req->setCredential($cred);
 		$handler->handle($httpConfig, $req, $options);
-		
+
 		$this->assertContains('<ebl:Username>', $req->getBindingInfo('securityHeader'));
-		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));		
+		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Subject>', $req->getBindingInfo('securityHeader'));
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
-		
-	
+
+
 		// Test that no auth related HTTP headers (username, password, sign?) are
 		// added for token based third party auth
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$req->setCredential(new PPCertificateCredential('user', 'pass', 'cacert.pem'));
-		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));		
+		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));
 		$handler->handle($httpConfig, $req, $options);
 
 		$this->assertContains('<ns:RequesterCredentials/>', $req->getBindingInfo('securityHeader'));
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
 		$this->assertArrayHasKey(CURLOPT_SSLCERT, $httpConfig->getCurlOptions());
 	}
-	
+
 }

--- a/tests/handlers/PPGenericServiceHandlerTest.php
+++ b/tests/handlers/PPGenericServiceHandlerTest.php
@@ -3,42 +3,43 @@
 use PayPal\Handler\PPGenericServiceHandler;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
+use PHPUnit\Framework\TestCase;
 
-class PPGenericServiceHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPGenericServiceHandlerTest extends TestCase {
+
 	protected function setup() {
-		
+
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAdded() {
 		$bindingType = 'bindingType';
 		$devEmail = 'developer@domain.com';
-		
-		
+
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPGenericServiceHandler('sdkname', 'sdkversion');
-		$handler->handle($httpConfig, 
-				new PPRequest(new StdClass(), $bindingType), 
+		$handler->handle($httpConfig,
+				new PPRequest(new StdClass(), $bindingType),
 				array('config' => array('service.SandboxEmailAddress' => $devEmail))
 		);
-		
-		$headers = $httpConfig->getHeaders();		
+
+		$headers = $httpConfig->getHeaders();
 		$this->assertEquals(6, count($headers));
 		$this->assertArrayHasKey('X-PAYPAL-DEVICE-IPADDRESS', $headers);
-		$this->assertArrayHasKey('X-PAYPAL-REQUEST-SOURCE', $headers);		
+		$this->assertArrayHasKey('X-PAYPAL-REQUEST-SOURCE', $headers);
 		$this->assertEquals($bindingType, $headers['X-PAYPAL-REQUEST-DATA-FORMAT']);
 		$this->assertEquals($bindingType, $headers['X-PAYPAL-RESPONSE-DATA-FORMAT']);
 		$this->assertEquals($devEmail, $headers['X-PAYPAL-SANDBOX-EMAIL-ADDRESS']);
-		
+
 	}
-	
+
 	/**
 	 * @test
 	 */

--- a/tests/handlers/PPMerchantServiceHandlerTest.php
+++ b/tests/handlers/PPMerchantServiceHandlerTest.php
@@ -6,126 +6,127 @@ use PayPal\Handler\PPMerchantServiceHandler;
 use PayPal\Core\PPConstants;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
+use PHPUnit\Framework\TestCase;
 
-class PPMerchantServiceHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPMerchantServiceHandlerTest extends TestCase {
+
 	private $options;
-	
+
 	protected function setup() {
 		$this->options = array(
 			'config' => array(
-				'mode' => 'sandbox', 
-				'acct1.UserName' => 'siguser', 
-				'acct1.Password' => 'pass', 
-				'acct1.Signature' => 'signature', 
-				'acct2.UserName' => 'certuser', 
-				'acct2.Password' => 'pass', 
-				'acct2.CertPath' => 'pathtocert', 
-			), 
-			'serviceName' => 'PayPalAPIInterfaceService', 
+				'mode' => 'sandbox',
+				'acct1.UserName' => 'siguser',
+				'acct1.Password' => 'pass',
+				'acct1.Signature' => 'signature',
+				'acct2.UserName' => 'certuser',
+				'acct2.Password' => 'pass',
+				'acct2.CertPath' => 'pathtocert',
+			),
+			'serviceName' => 'PayPalAPIInterfaceService',
 			'apiMethod' => 'DoExpressCheckout',
 			'port' => 'apiAA'
 		);
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAdded() {
-		
+
 		$req = new PPRequest(new StdClass(), 'SOAP');
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPMerchantServiceHandler(null, 'sdkname', 'sdkversion');
 		$handler->handle($httpConfig, $req, $this->options);
-		
+
 		$this->assertEquals(5, count($httpConfig->getHeaders()), "Basic headers not added");
-		
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testModeBasedEndpointForSignatureCredential() {
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPMerchantServiceHandler(null, 'sdkname', 'sdkversion');
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$req->setCredential(new PPSignatureCredential('a', 'b', 'c'));
-		
+
 		$handler->handle($httpConfig, $req, $this->options);
 		$this->assertEquals(PPConstants::MERCHANT_SANDBOX_SIGNATURE_ENDPOINT, $httpConfig->getUrl());
-		
+
 		$options = $this->options;
 		$options['config']['mode'] = 'live';
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(PPConstants::MERCHANT_LIVE_SIGNATURE_ENDPOINT, $httpConfig->getUrl());
-		
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function testModeBasedEndpointForCertificateCredential() {
-	
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPMerchantServiceHandler('certuser', 'sdkname', 'sdkversion');
 		$req = new PPRequest(new StdClass(), 'SOAP');
-	
+
 		$handler->handle($httpConfig, $req, $this->options);
 		$this->assertEquals(PPConstants::MERCHANT_SANDBOX_CERT_ENDPOINT, $httpConfig->getUrl());
-	
+
 		$options = $this->options;
 		$options['config']['mode'] = 'live';
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(PPConstants::MERCHANT_LIVE_CERT_ENDPOINT, $httpConfig->getUrl());
-	
+
 	}
-	
-	
+
+
 	public function testCustomEndpoint() {
 
 		$customEndpoint = 'http://myhost/';
 		$options = $this->options;
 		$options['config']['service.EndPoint'] = $customEndpoint;
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPMerchantServiceHandler(null, 'sdkname', 'sdkversion');
-		
+
 		$handler->handle($httpConfig,
-				new PPRequest(new StdClass(), 'SOAP'), $options			
+				new PPRequest(new StdClass(), 'SOAP'), $options
 		);
 		$this->assertEquals("$customEndpoint", $httpConfig->getUrl(), "Custom endpoint not processed");
-	
+
 		$options['config']['service.EndPoint'] = 'abc';
 		$options['config']["service.EndPoint.". $options['port']] = $customEndpoint;
 		$handler->handle($httpConfig,
 				new PPRequest(new StdClass(), 'SOAP'), $options
 		);
 		$this->assertEquals("$customEndpoint", $httpConfig->getUrl(), "Custom endpoint not processed");
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	 public function testInvalidConfigurations() {
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPMerchantServiceHandler(null, 'sdkname', 'sdkversion');
-		
+
 		$this->setExpectedException('PayPal\Exception\PPMissingCredentialException');
 		$handler->handle($httpConfig,
 				new PPRequest(new StdClass(), 'SOAP'),
 				array('config' => array())
 		);
 		$this->setExpectedException('PayPal\Exception\PPConfigurationException');
-		
-		
+
+
 		$options = $this->options;
 		unset($options['mode']);
 		$handler->handle($httpConfig,

--- a/tests/handlers/PPOpenIdHandlerTest.php
+++ b/tests/handlers/PPOpenIdHandlerTest.php
@@ -4,17 +4,18 @@ use PayPal\Core\PPConstants;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
 use PayPal\Handler\PPOpenIdHandler;
+use PHPUnit\Framework\TestCase;
 
-class PPOpenIdHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPOpenIdHandlerTest extends TestCase {
+
 	protected function setup() {
-		
+
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -22,54 +23,54 @@ class PPOpenIdHandlerTest extends PHPUnit_Framework_TestCase {
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('mode' => 'unknown', 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-	
+
 		$this->setExpectedException('PayPal\Exception\PPConfigurationException');
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
-		
-		
+
+
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler($apiContext);
-		
+
 		$this->setExpectedException('PayPal\Exception\PPConfigurationException');
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAdded() {
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('mode' => 'sandbox', 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
-		
+
 		$handler = new PPOpenIdHandler();
 		$handler->handle($httpConfig, 'payload', array('apiContext' => $apiContext));
-		
+
 		$this->assertArrayHasKey('Authorization', $httpConfig->getHeaders());
-		$this->assertArrayHasKey('User-Agent', $httpConfig->getHeaders());			
+		$this->assertArrayHasKey('User-Agent', $httpConfig->getHeaders());
 		$this->assertContains('PayPalSDK', $httpConfig->getHeader('User-Agent'));
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testModeBasedEndpoint() {
 		$httpConfig = new PPHttpConfig();
-		$apiContext = new PPApiContext(array('mode' => 'sandbox', 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));		
+		$apiContext = new PPApiContext(array('mode' => 'sandbox', 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-		
+
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 		$this->assertEquals(PPConstants::REST_SANDBOX_ENDPOINT . "path", $httpConfig->getUrl());
-		
-		
+
+
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('mode' => 'live', 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-		
+
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 		$this->assertEquals(PPConstants::REST_LIVE_ENDPOINT . "path", $httpConfig->getUrl());
 	}
-	
+
 	/**
 	 * @test
 	 */
@@ -78,27 +79,27 @@ class PPOpenIdHandlerTest extends PHPUnit_Framework_TestCase {
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('service.EndPoint' => $customEndpoint, 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-		
+
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 		$this->assertEquals("$customEndpoint/path", $httpConfig->getUrl());
-		
-		
+
+
 		$customEndpoint = 'http://mydomain/';
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('service.EndPoint' => $customEndpoint, 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-		
+
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 		$this->assertEquals("${customEndpoint}path", $httpConfig->getUrl());
-		
-		
+
+
 		$customEndpoint = 'http://mydomain';
 		$httpConfig = new PPHttpConfig();
 		$apiContext = new PPApiContext(array('service.EndPoint' => 'xyz', 'openid.EndPoint' => $customEndpoint, 'acct1.ClientId' => 'clientId', 'acct1.ClientSecret' => 'clientSecret'));
 		$handler = new PPOpenIdHandler();
-		
+
 		$handler->handle($httpConfig, 'payload', array('path' => '/path', 'apiContext' => $apiContext));
 		$this->assertEquals("$customEndpoint/path", $httpConfig->getUrl());
 	}
-	
+
 }

--- a/tests/handlers/PPPlatformServiceHandlerTest.php
+++ b/tests/handlers/PPPlatformServiceHandlerTest.php
@@ -4,36 +4,37 @@ use PayPal\Core\PPConstants;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
 use PayPal\Handler\PPPlatformServiceHandler;
+use PHPUnit\Framework\TestCase;
 
-class PPPlatformServiceHandlerTest extends PHPUnit_Framework_TestCase {
+class PPPlatformServiceHandlerTest extends TestCase {
 
 	private $options;
-	
+
 	protected function setup() {
 		$this->options = array(
 			'config' => array(
-				'mode' => 'sandbox', 
-				'acct1.UserName' => 'user', 
-				'acct1.Password' => 'pass', 
-				'acct1.Signature' => 'sign', 
+				'mode' => 'sandbox',
+				'acct1.UserName' => 'user',
+				'acct1.Password' => 'pass',
+				'acct1.Signature' => 'sign',
 				'acct1.AppId' => 'APP',
-				'acct2.UserName' => 'certuser', 
-				'acct2.Password' => 'pass', 
-				'acct2.CertPath' => 'pathtocert', 
-			), 
-			'serviceName' => 'AdaptivePayments', 
+				'acct2.UserName' => 'certuser',
+				'acct2.Password' => 'pass',
+				'acct2.CertPath' => 'pathtocert',
+			),
+			'serviceName' => 'AdaptivePayments',
 			'apiMethod' => 'ConvertCurrency');
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testDefaultAPIAccount() {
-		
+
 		$req = new PPRequest(new StdClass(), 'NV');
 
 		$httpConfig = new PPHttpConfig();
@@ -41,48 +42,48 @@ class PPPlatformServiceHandlerTest extends PHPUnit_Framework_TestCase {
 		$handler->handle($httpConfig, $req, $this->options);
 		$this->assertEquals($this->options['config']['acct1.Signature'], $req->getCredential()->getSignature());
 
-		
+
 		$cred = new PPSignatureCredential('user', 'pass', 'sig');
 		$cred->setApplicationId('appId');
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPPlatformServiceHandler($cred, 'sdkname', 'sdkversion');
-		$handler->handle($httpConfig, $req, $this->options);		
-		
+		$handler->handle($httpConfig, $req, $this->options);
+
 		$this->assertEquals($cred, $req->getCredential());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAdded() {
-		
+
 		$req = new PPRequest(new StdClass(), 'NV');
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPPlatformServiceHandler(null, 'sdkname', 'sdkversion');
 		$handler->handle($httpConfig, $req, $this->options);
-		
+
 		$this->assertEquals(9, count($httpConfig->getHeaders()), "Basic headers not added");
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPPlatformServiceHandler('certuser', 'sdkname', 'sdkversion');
 		$handler->handle($httpConfig, $req, $this->options);
-		
+
 		$this->assertEquals(7, count($httpConfig->getHeaders()));
 		$this->assertEquals('certuser', $req->getCredential()->getUsername());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testEndpoint() {
 		$serviceName = 'AdaptivePayments';
 		$apiMethod = 'ConvertCurrency';
-		
+
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPPlatformServiceHandler(null, 'sdkname', 'sdkversion');
-		
+
 		$handler->handle($httpConfig,
 				new PPRequest(new StdClass(), 'NV'),
 				$this->options
@@ -96,8 +97,8 @@ class PPPlatformServiceHandlerTest extends PHPUnit_Framework_TestCase {
 				$options
 		);
 		$this->assertEquals(PPConstants::PLATFORM_LIVE_ENDPOINT . "$serviceName/$apiMethod", $httpConfig->getUrl());
-		
-		
+
+
 		$customEndpoint = 'http://myhost/';
 		$options = $this->options;
 		$options['config']['service.EndPoint'] = $customEndpoint;
@@ -106,7 +107,7 @@ class PPPlatformServiceHandlerTest extends PHPUnit_Framework_TestCase {
 				$options
 		);
 		$this->assertEquals("$customEndpoint$serviceName/$apiMethod", $httpConfig->getUrl(), "Custom endpoint not processed");
-		
+
 	}
 
 	/**
@@ -115,13 +116,13 @@ class PPPlatformServiceHandlerTest extends PHPUnit_Framework_TestCase {
 	 public function testInvalidConfigurations() {
 		$httpConfig = new PPHttpConfig();
 		$handler = new PPPlatformServiceHandler(null, 'sdkname', 'sdkversion');
-		
+
 		$this->setExpectedException('PayPal\Exception\PPMissingCredentialException');
 		$handler->handle($httpConfig,
 				new PPRequest(new StdClass(), 'NV'),
 				array('config' => array())
 		);
-		
+
 		$this->setExpectedException('PayPal\Exception\PPConfigurationException');
 		$options = $this->options;
 		unset($options['mode']);

--- a/tests/handlers/PPSignatureAuthHandlerTest.php
+++ b/tests/handlers/PPSignatureAuthHandlerTest.php
@@ -6,38 +6,39 @@ use PayPal\Auth\PPTokenAuthorization;
 use PayPal\Core\PPHttpConfig;
 use PayPal\Core\PPRequest;
 use PayPal\Handler\PPSignatureAuthHandler;
+use PHPUnit\Framework\TestCase;
 
-class PPSignatureAuthHandlerTest extends PHPUnit_Framework_TestCase {
-	
+class PPSignatureAuthHandlerTest extends TestCase {
+
 	protected function setup() {
-		
+
 	}
-	
+
 	protected function tearDown() {
-	
+
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAddedForNVP() {
-		
+
 		$req = new PPRequest(new StdClass(), 'NV');
 		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');
-						
+
 		$handler = new PPSignatureAuthHandler();
-		
+
 		// Test that no headers are added if no credential is passed
 		$httpConfig = new PPHttpConfig();
-		$handler->handle($httpConfig, $req, $options);		
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
-		
+
 		// Test that the 3 token headers are added for first party API calls
 		$httpConfig = new PPHttpConfig();
-		$cred = new PPSignatureCredential('user', 'pass', 'sign');		
+		$cred = new PPSignatureCredential('user', 'pass', 'sign');
 		$req->setCredential($cred);
-		
-		$handler->handle($httpConfig, $req, $options);		
+
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(3, count($httpConfig->getHeaders()));
 
 		// Test addition of 'subject' HTTP header for subject based third party auth
@@ -45,69 +46,69 @@ class PPSignatureAuthHandlerTest extends PHPUnit_Framework_TestCase {
 		$cred = new PPSignatureCredential('user', 'pass', 'sign');
 		$cred->setThirdPartyAuthorization(new PPSubjectAuthorization('email@paypal.com'));
 		$req->setCredential($cred);
-		
+
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(4, count($httpConfig->getHeaders()));
 		$this->assertArrayHasKey('X-PAYPAL-SECURITY-SUBJECT', $httpConfig->getHeaders());
-	
-		// Test that no auth related HTTP headers (username, password, sign?) are 
+
+		// Test that no auth related HTTP headers (username, password, sign?) are
 		// added for token based third party auth
 		$httpConfig = new PPHttpConfig();
 		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));
-				
-		$handler->handle($httpConfig, $req, $options);		
+
+		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
-	
+
 	}
-	
-	
+
+
 	/**
 	 * @test
 	 */
 	public function testHeadersAddedForSOAP() {
-	
-		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');		
+
+		$options = array('config' => array('mode' => 'sandbox'), 'serviceName' => 'AdaptivePayments', 'apiMethod' => 'ConvertCurrency');
 		$req = new PPRequest(new StdClass(), 'SOAP');
-		
+
 		$handler = new PPSignatureAuthHandler();
-		
+
 		// Test that no headers are added if no credential is passed
 		$httpConfig = new PPHttpConfig();
 		$handler->handle($httpConfig, $req, $options);
 		$this->assertEquals('', $req->getBindingInfo('securityHeader'));
-		
-		
+
+
 		// Test that the 3 token SOAP headers are added for first party API calls
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$req->setCredential(new PPSignatureCredential('user', 'pass', 'sign'));
 		$handler->handle($httpConfig, $req, $options);
-		
+
 		$this->assertContains('<ebl:Username>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Signature>', $req->getBindingInfo('securityHeader'));
-	
+
 		// Test addition of 'subject' SOAP header for subject based third party auth
 		$req = new PPRequest(new StdClass(), 'SOAP');
 		$cred = new PPSignatureCredential('user', 'pass', 'sign');
 		$cred->setThirdPartyAuthorization(new PPSubjectAuthorization('email@paypal.com'));
 		$req->setCredential($cred);
 		$handler->handle($httpConfig, $req, $options);
-		
+
 		$this->assertContains('<ebl:Username>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Password>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Signature>', $req->getBindingInfo('securityHeader'));
 		$this->assertContains('<ebl:Subject>', $req->getBindingInfo('securityHeader'));
-		
-	
+
+
 		// Test that no auth related HTTP headers (username, password, sign?) are
 		// added for token based third party auth
-		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));		
+		$req->getCredential()->setThirdPartyAuthorization(new PPTokenAuthorization('token', 'tokenSecret'));
 		$handler->handle($httpConfig, $req, $options);
 
 		$this->assertContains('<ns:RequesterCredentials/>', $req->getBindingInfo('securityHeader'));
 		$this->assertEquals(0, count($httpConfig->getHeaders()));
-	
+
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.

PS: Should we move `PHP 5.3` to [run on Precise at `Travis CI`](https://docs.travis-ci.com/user/reference/trusty#PHP-images)?