### PR TITLE
Fixed "SSL version  range is not valid"

### DIFF
--- a/lib/PayPal/Core/PPHttpConnection.php
+++ b/lib/PayPal/Core/PPHttpConnection.php
@@ -59,7 +59,8 @@ class PPHttpConnection
         curl_setopt($ch, CURLOPT_URL, $this->httpConfig->getUrl());
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getHttpHeaders());
-
+		curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
+		
         switch ($this->httpConfig->getMethod()) {
             case 'POST':
                 curl_setopt($ch, CURLOPT_POST, true);


### PR DESCRIPTION
Fixed error "SSL version range is not valid" that prevented payments as curl was defaulting to an unsupported version