### PR TITLE
Use default cipher list

### DIFF
--- a/lib/PayPal/Core/PPHttpConfig.php
+++ b/lib/PayPal/Core/PPHttpConfig.php
@@ -19,7 +19,6 @@ class PPHttpConfig
       CURLOPT_HTTPHEADER      => array(),
       CURLOPT_SSL_VERIFYHOST  => 2,
       CURLOPT_SSL_VERIFYPEER  => 1,
-      CURLOPT_SSL_CIPHER_LIST => 'TLSv1',
     );
 
     const HEADER_SEPARATOR = ';';


### PR DESCRIPTION
The current setting uses TLS1.0 ciphers which fail in some circumstances.
I chose to remove this default setting because it only be changed by custom config, and not removed.
See Case # 06169024