### PR TITLE
Extend PHPUtils, add method that converts NVP without urldecode

### DIFF
--- a/lib/PayPal/Core/PPUtils.php
+++ b/lib/PayPal/Core/PPUtils.php
@@ -25,6 +25,26 @@ class PPUtils
     }
 
     /**
+     *
+     * Convert a Name Value Pair (NVP) formatted
+     * string int an associative array
+     *
+     * @param string $nvpString
+     *
+     * @return array
+     */
+    public static function nvpToMapWithoutUrlDecode($nvpString)
+    {
+        $ret    = array();
+        $params = explode("&", $nvpString);
+        foreach ($params as $p) {
+            list($k, $v) = explode("=", $p);
+            $ret[$k] = $v;
+        }
+        return $ret;
+    }
+
+    /**
      * Returns true if the array contains a key like $key
      *
      * @param array  $map


### PR DESCRIPTION
Hello,
 here is the reference to the issue that I am trying to solve https://github.com/paypal/permissions-sdk-php/issues/22 . As far as I see, to properly do the fix, we have to update two repositories, and currently it is the biggest question, because PR for **paypal/permissions-sdk-php** will be dependable on the PR in **paypal/sdk-core-php**, please advise here

Description of the issue located in the https://github.com/paypal/permissions-sdk-php/issues/22 

Let me know if you have any question, or need more details.  