### PR TITLE
Allow consumers to be informed when we attempt retries

### DIFF
--- a/lib/PayPal/Core/PPConnectionManager.php
+++ b/lib/PayPal/Core/PPConnectionManager.php
@@ -26,6 +26,7 @@ class PPConnectionManager
      */
     public function getConnection($httpConfig, $config)
     {
+        /** @var PPHttpConfig $httpConfig */
         if (isset($config["http.ConnectionTimeOut"])) {
             $httpConfig->setHttpConnectionTimeout($config["http.ConnectionTimeOut"]);
         }
@@ -38,6 +39,10 @@ class PPConnectionManager
         if (isset($config["http.Retry"])) {
             $retry = $config["http.Retry"];
             $httpConfig->setHttpRetryCount($retry);
+        }
+        if (isset($config["http.RetryInformCallback"])) {
+            $retryCallback = $config["http.RetryInformCallback"];
+            $httpConfig->setRetryInformCallback($retryCallback);
         }
 
         return new PPHttpConnection($httpConfig, $config);

--- a/lib/PayPal/Core/PPHttpConfig.php
+++ b/lib/PayPal/Core/PPHttpConfig.php
@@ -39,6 +39,12 @@ class PPHttpConfig
     private $retryCount;
 
     /**
+     * Consumer can choose to be informed when retries are attempted.
+     * @var callable|null
+     */
+    private $retryInformCallback;
+
+    /**
      *
      * @param string $url
      * @param string $method  HTTP method (GET, POST etc) defaults to POST
@@ -197,6 +203,16 @@ class PPHttpConfig
     public function getHttpRetryCount()
     {
         return $this->retryCount;
+    }
+
+    public function setRetryInformCallback(callable $callback)
+    {
+        $this->retryInformCallback = $callback;
+    }
+
+    public function getRetryInformCallback()
+    {
+        return $this->retryInformCallback;
     }
 
     /**

--- a/tests/PPConnectionManagerTest.php
+++ b/tests/PPConnectionManagerTest.php
@@ -74,5 +74,30 @@ class PPConnectionManagerTest extends TestCase
         $this->assertTrue($conn instanceof PPHttpConnection);
         $this->assertEquals("PayPal\Core\PPHttpConnection", get_class($conn));
     }
+
+
+    /**
+     * @test
+     */
+    public function testGetConnectionSetsRetryInformCallbackAttribute()
+    {
+        $test = 0;
+
+        $configParams = $this->config;
+        $configParams['http.RetryInformCallback'] = function ($arg) use (&$test) {
+            $test = 1337;
+        };
+
+        $connection = $this->object->getConnection(new PPHttpConfig("http://domain.com"), $configParams);
+
+        $this->assertTrue(is_callable($connection->getHttpConfig()->getRetryInformCallback()));
+
+        $curlClientReflector = new \ReflectionClass($connection);
+        $informMethod = $curlClientReflector->getMethod('informOfRetry');
+        $informMethod->setAccessible(true);
+        $informMethod->invoke($connection, 1);
+
+        $this->assertEquals(1337, $test);
+    }
 }
 ?>

--- a/tests/PPHttpConfigTest.php
+++ b/tests/PPHttpConfigTest.php
@@ -119,5 +119,18 @@ class PPHttpConfigTest extends TestCase
     	$this->setExpectedException('PayPal\Exception\PPConfigurationException');
     	$o->setHttpProxy('invalid string');
     }
+
+    public function testInformCallBack()
+	{
+		$test = 0;
+		$config = new PPHttpConfig();
+		$config->setRetryInformCallback(function () use (&$test) {
+			$test = 2;
+		});
+		$args = array($test);
+		call_user_func_array($config->getRetryInformCallback(), $args);
+
+		$this->assertEquals(2, $test);
+	}
 }
 ?>


### PR DESCRIPTION
This adds a new configuration that allows consuming code to get notified when a retry is attempted. This is helpful for monitoring, to find recurring network issues