### PR TITLE
Check PHP version is lower than 7.4 before calling get_magic_quotes_g…

### DIFF
--- a/lib/PayPal/IPN/PPIPNMessage.php
+++ b/lib/PayPal/IPN/PPIPNMessage.php
@@ -81,7 +81,7 @@ class PPIPNMessage
             return $this->isIpnVerified;
         } else {
             $request = self::IPN_CMD;
-            if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
+            if (\PHP_VERSION_ID < 70400 && function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
                 $get_magic_quotes_exists = true;
             } else {
                 $get_magic_quotes_exists = false;


### PR DESCRIPTION
…pc to avoid E_DEPRECATED error.

In PHP 7.4 get_magic_quotes_gpc() always return false. When error_reporting includes E_DEPRECATED usage of PPIPNMessage::validate will raise an error. In PHP >=7.4 get_magic_quotes_gpc cannot be used, so there is no need to try to run it.